### PR TITLE
Migrate DatePicker to use Temporal, including the related usages

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
     "react-fast-compare": "^3.2.2",
+    "temporal-polyfill": "^1.0.1",
     "url-regex-safe": "^4.0.0",
     "wouter": "~3.10.0",
     "zustand": "~5.0.14"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -72,6 +72,9 @@ importers:
       react-fast-compare:
         specifier: ^3.2.2
         version: 3.2.2
+      temporal-polyfill:
+        specifier: ^1.0.1
+        version: 1.0.1
       url-regex-safe:
         specifier: ^4.0.0
         version: 4.0.0
@@ -3741,6 +3744,15 @@ packages:
   tapable@2.3.3:
     resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
     engines: {node: '>=6'}
+
+  temporal-polyfill@1.0.1:
+    resolution: {integrity: sha512-N2SoI9olnW7BUsU8RosDphZQl9s+WJ8O7PoJMFCr/e5/1rFkVI4GNOWaSeySG+UoP04foPYsnLWbJmbXOiShZg==}
+
+  temporal-spec@1.0.0:
+    resolution: {integrity: sha512-00Ahj1e1ifaERTMOIIGpOCdOo9IEk2m6GGSMedsn9a2SIsGLdOTbmME1Htv6IM82b6VHrzSUTIVc7YHy6hdhFQ==}
+
+  temporal-utils@1.0.1:
+    resolution: {integrity: sha512-HAixuesxFQIUaQk3ptX2jhfO/FsOkgVkDDMawvp6n/fkB1q6BKfs3lURw9I+pK/2e2e/q/vrLrxmeqauBoyGMQ==}
 
   terser-webpack-plugin@5.6.1:
     resolution: {integrity: sha512-201R5j+sJpK8nFWwKVyNfZot8FaJbLZDq5evriVzbV1wDtSXDjRUDRfJzHpAaxFDMEhsZL1QkeqM61wgsS3KaQ==}
@@ -7795,6 +7807,15 @@ snapshots:
   sync-message-port@1.2.0: {}
 
   tapable@2.3.3: {}
+
+  temporal-polyfill@1.0.1:
+    dependencies:
+      temporal-spec: 1.0.0
+      temporal-utils: 1.0.1
+
+  temporal-spec@1.0.0: {}
+
+  temporal-utils@1.0.1: {}
 
   terser-webpack-plugin@5.6.1(webpack@5.99.6):
     dependencies:

--- a/src/Accommodation/AccommodationDialog/AccommodationDialogContentEdit.tsx
+++ b/src/Accommodation/AccommodationDialog/AccommodationDialogContentEdit.tsx
@@ -1,5 +1,4 @@
 import { Box, Dialog, Spinner } from '@radix-ui/themes';
-import { DateTime } from 'luxon';
 import { useCallback } from 'react';
 import type { DialogContentProps } from '../../Dialog/DialogRoute';
 import { useTrip } from '../../Trip/store/hooks';
@@ -17,26 +16,30 @@ export function AccommodationDialogContentEdit({
 }: DialogContentProps<TripSliceAccommodation>) {
   const { trip } = useTrip(accommodation?.tripId);
 
-  const tripStartDateTime = trip
-    ? DateTime.fromMillis(trip.timestampStart).setZone(trip.timeZone)
-    : undefined;
-  const tripEndDateTime = trip
-    ? DateTime.fromMillis(trip.timestampEnd)
-        .setZone(trip.timeZone)
-        .minus({ minute: 1 })
-    : undefined;
-
-  const accommodationCheckInDateTime =
+  const tripStartDateTime =
     accommodation && trip
-      ? DateTime.fromMillis(accommodation.timestampCheckIn).setZone(
-          accommodation.timeZoneCheckIn ?? trip.timeZone,
-        )
+      ? Temporal.Instant.fromEpochMilliseconds(trip.timestampStart)
+          .toZonedDateTimeISO(trip.timeZone)
+          .toPlainDate()
+      : undefined;
+  const tripEndDateTime =
+    accommodation && trip
+      ? Temporal.Instant.fromEpochMilliseconds(trip.timestampEnd)
+          .toZonedDateTimeISO(trip.timeZone)
+          .toPlainDate()
+          .subtract({ days: 1 })
+      : undefined;
+  const accommodationCheckInDateTime =
+    accommodation && trip && accommodation.timestampCheckIn != null
+      ? Temporal.Instant.fromEpochMilliseconds(accommodation.timestampCheckIn)
+          .toZonedDateTimeISO(accommodation.timeZoneCheckIn ?? trip.timeZone)
+          .toPlainDateTime()
       : undefined;
   const accommodationCheckOutDateTime =
-    accommodation && trip
-      ? DateTime.fromMillis(accommodation.timestampCheckOut).setZone(
-          accommodation.timeZoneCheckOut ?? trip.timeZone,
-        )
+    accommodation && trip && accommodation.timestampCheckOut != null
+      ? Temporal.Instant.fromEpochMilliseconds(accommodation.timestampCheckOut)
+          .toZonedDateTimeISO(accommodation.timeZoneCheckOut ?? trip.timeZone)
+          .toPlainDateTime()
       : undefined;
   const backToViewMode = useCallback(() => {
     setMode(AccommodationDialogMode.View);
@@ -70,6 +73,12 @@ export function AccommodationDialogContentEdit({
           accommodationAddress={accommodation.address}
           accommodationCheckInDateTime={accommodationCheckInDateTime}
           accommodationCheckOutDateTime={accommodationCheckOutDateTime}
+          accommodationCheckInTimeZone={
+            accommodation.timeZoneCheckIn ?? trip.timeZone
+          }
+          accommodationCheckOutTimeZone={
+            accommodation.timeZoneCheckOut ?? trip.timeZone
+          }
           accommodationPhoneNumber={accommodation.phoneNumber}
           accommodationNotes={accommodation.notes}
           accommodationLocationLat={accommodation.locationLat}

--- a/src/Accommodation/AccommodationForm/AccommodationForm.tsx
+++ b/src/Accommodation/AccommodationForm/AccommodationForm.tsx
@@ -104,6 +104,7 @@ export function AccommodationForm({
 
   tripTimeZone: string;
   tripStartDateTime: Temporal.PlainDate | undefined;
+  /** Trip's final day */
   tripEndDateTime: Temporal.PlainDate | undefined;
   tripRegion: string;
 
@@ -284,7 +285,10 @@ export function AccommodationForm({
         return;
       }
       if (
-        Temporal.PlainDateTime.compare(timeCheckOutDate, timeCheckInDate) < 0
+        Temporal.PlainDateTime.compare(
+          zonedCheckOutDateTime,
+          zonedCheckInDateTime,
+        ) < 0
       ) {
         setErrorMessage('Check out time must be after check in time');
         return;
@@ -305,7 +309,7 @@ export function AccommodationForm({
         tripEndDateTime &&
         Temporal.ZonedDateTime.compare(
           zonedCheckOutDateTime,
-          tripEndDateTime.toZonedDateTime(tripTimeZone),
+          tripEndDateTime.toZonedDateTime(tripTimeZone).add({ days: 1 }),
         ) > 0
       ) {
         setErrorMessage('Check out time cannot be later than trip end time');

--- a/src/Accommodation/AccommodationForm/AccommodationForm.tsx
+++ b/src/Accommodation/AccommodationForm/AccommodationForm.tsx
@@ -285,7 +285,7 @@ export function AccommodationForm({
         return;
       }
       if (
-        Temporal.PlainDateTime.compare(
+        Temporal.ZonedDateTime.compare(
           zonedCheckOutDateTime,
           zonedCheckInDateTime,
         ) < 0

--- a/src/Accommodation/AccommodationForm/AccommodationForm.tsx
+++ b/src/Accommodation/AccommodationForm/AccommodationForm.tsx
@@ -484,9 +484,8 @@ export function AccommodationForm({
           required
           aria-label="Accommodation check in time"
           placeholder="Select check in time"
-          // Buffer one day before and after trip start/end date to allow some flexibility
-          min={tripStartDateTime?.subtract({ days: 1 })}
-          max={tripEndDateTime?.add({ days: 1 })}
+          min={tripStartDateTime}
+          max={tripEndDateTime}
         />
         <Text as="label">
           Check out time zone{' '}
@@ -515,9 +514,8 @@ export function AccommodationForm({
           required
           aria-label="Accommodation check out time"
           placeholder="Select check out time"
-          // Buffer one day before and after trip start/end date to allow some flexibility
-          min={tripStartDateTime?.subtract({ days: 1 })}
-          max={tripEndDateTime?.add({ days: 1 })}
+          min={tripStartDateTime}
+          max={tripEndDateTime}
         />
         <Text as="label" htmlFor={idPhoneNumber}>
           Phone number

--- a/src/Accommodation/AccommodationForm/AccommodationForm.tsx
+++ b/src/Accommodation/AccommodationForm/AccommodationForm.tsx
@@ -6,7 +6,6 @@ import {
   TextArea,
   TextField,
 } from '@radix-ui/themes';
-import type { DateTime } from 'luxon';
 import type { SubmitEvent } from 'react';
 import { useCallback, useId, useReducer, useState } from 'react';
 import { DateTimePicker } from '../../common/DatePicker2/DateTimePicker';
@@ -88,6 +87,8 @@ export function AccommodationForm({
   accommodationAddress,
   accommodationCheckInDateTime,
   accommodationCheckOutDateTime,
+  accommodationCheckInTimeZone,
+  accommodationCheckOutTimeZone,
   accommodationPhoneNumber,
   accommodationNotes,
   accommodationLocationLat,
@@ -102,14 +103,17 @@ export function AccommodationForm({
   accommodationId?: string;
 
   tripTimeZone: string;
-  tripStartDateTime: DateTime | undefined;
-  tripEndDateTime: DateTime | undefined;
+  tripStartDateTime: Temporal.PlainDate | undefined;
+  tripEndDateTime: Temporal.PlainDate | undefined;
   tripRegion: string;
 
   accommodationName: string;
   accommodationAddress: string;
-  accommodationCheckInDateTime: DateTime | undefined;
-  accommodationCheckOutDateTime: DateTime | undefined;
+  accommodationCheckInDateTime: Temporal.PlainDateTime | undefined;
+  accommodationCheckOutDateTime: Temporal.PlainDateTime | undefined;
+  accommodationCheckInTimeZone: string | undefined;
+  accommodationCheckOutTimeZone: string | undefined;
+
   accommodationPhoneNumber: string;
   accommodationNotes: string;
   accommodationLocationLat: number | null | undefined;
@@ -127,25 +131,44 @@ export function AccommodationForm({
   const publishToast = useBoundStore((state) => state.publishToast);
 
   const [errorMessage, setErrorMessage] = useState('');
-  const [checkInDateTime, setCheckInDateTime] = useState<DateTime | undefined>(
-    accommodationCheckInDateTime,
-  );
+  const [checkInDateTime, setCheckInDateTime] = useState<
+    Temporal.PlainDateTime | undefined
+  >(accommodationCheckInDateTime);
   const [checkOutDateTime, setCheckOutDateTime] = useState<
-    DateTime | undefined
+    Temporal.PlainDateTime | undefined
   >(accommodationCheckOutDateTime);
+
+  const [checkInTimeZone, setCheckInTimeZone] = useState<string>(
+    accommodationCheckInTimeZone ?? tripTimeZone,
+  );
+  const [checkOutTimeZone, setCheckOutTimeZone] = useState<string>(
+    accommodationCheckOutTimeZone ?? tripTimeZone,
+  );
 
   // Handlers for date changes
   const handleCheckInDateChange = useCallback(
-    (dateTime: DateTime | undefined) => {
-      setCheckInDateTime(dateTime);
+    (newDate: Temporal.PlainDate | Temporal.PlainDateTime | undefined) => {
+      if (newDate instanceof Temporal.PlainDate) {
+        setCheckInDateTime(
+          newDate.toPlainDateTime({ hour: 12, minute: 0, second: 0 }),
+        );
+      } else {
+        setCheckInDateTime(newDate);
+      }
       setErrorMessage(''); // Clear any date-related errors
     },
     [],
   );
 
   const handleCheckOutDateChange = useCallback(
-    (dateTime: DateTime | undefined) => {
-      setCheckOutDateTime(dateTime);
+    (newDate: Temporal.PlainDate | Temporal.PlainDateTime | undefined) => {
+      if (newDate instanceof Temporal.PlainDate) {
+        setCheckOutDateTime(
+          newDate.toPlainDateTime({ hour: 12, minute: 0, second: 0 }),
+        );
+      } else {
+        setCheckOutDateTime(newDate);
+      }
       setErrorMessage(''); // Clear any date-related errors
     },
     [],
@@ -235,6 +258,10 @@ export function AccommodationForm({
       const notes = (formData.get('notes') as string | null) ?? '';
       const timeCheckInDate = checkInDateTime;
       const timeCheckOutDate = checkOutDateTime;
+      const zonedCheckInDateTime =
+        timeCheckInDate?.toZonedDateTime(checkInTimeZone);
+      const zonedCheckOutDateTime =
+        timeCheckOutDate?.toZonedDateTime(checkOutTimeZone);
       console.log('AccommodationForm', {
         mode,
         accommodationId,
@@ -247,20 +274,40 @@ export function AccommodationForm({
         timeCheckOutDate,
         coordinateState,
       });
-      if (!name || !timeCheckInDate || !timeCheckOutDate) {
+      if (
+        !name ||
+        !timeCheckInDate ||
+        !timeCheckOutDate ||
+        !zonedCheckInDateTime ||
+        !zonedCheckOutDateTime
+      ) {
         return;
       }
-      if (timeCheckOutDate.diff(timeCheckInDate).as('minute') < 0) {
+      if (
+        Temporal.PlainDateTime.compare(timeCheckOutDate, timeCheckInDate) < 0
+      ) {
         setErrorMessage('Check out time must be after check in time');
         return;
       }
       // check in time cannot be earlier than trip start time
-      if (tripStartDateTime && timeCheckInDate < tripStartDateTime) {
+      if (
+        tripStartDateTime &&
+        Temporal.ZonedDateTime.compare(
+          zonedCheckInDateTime,
+          tripStartDateTime.toZonedDateTime(tripTimeZone),
+        ) < 0
+      ) {
         setErrorMessage('Check in time cannot be earlier than trip start time');
         return;
       }
       // check out time cannot be later than trip end time
-      if (tripEndDateTime && timeCheckOutDate > tripEndDateTime) {
+      if (
+        tripEndDateTime &&
+        Temporal.ZonedDateTime.compare(
+          zonedCheckOutDateTime,
+          tripEndDateTime.toZonedDateTime(tripTimeZone),
+        ) > 0
+      ) {
         setErrorMessage('Check out time cannot be later than trip end time');
         return;
       }
@@ -269,10 +316,10 @@ export function AccommodationForm({
           id: accommodationId,
           name,
           address,
-          timestampCheckIn: timeCheckInDate.toMillis(),
-          timestampCheckOut: timeCheckOutDate.toMillis(),
-          timeZoneCheckIn: timeCheckInDate.zoneName,
-          timeZoneCheckOut: timeCheckOutDate.zoneName,
+          timestampCheckIn: zonedCheckInDateTime.epochMilliseconds,
+          timestampCheckOut: zonedCheckOutDateTime.epochMilliseconds,
+          timeZoneCheckIn: checkInTimeZone,
+          timeZoneCheckOut: checkOutTimeZone,
           phoneNumber,
           notes,
           locationLat: coordinateState.enabled ? coordinateState.lat : null,
@@ -289,10 +336,10 @@ export function AccommodationForm({
           {
             name,
             address,
-            timestampCheckIn: timeCheckInDate.toMillis(),
-            timestampCheckOut: timeCheckOutDate.toMillis(),
-            timeZoneCheckIn: timeCheckInDate.zoneName,
-            timeZoneCheckOut: timeCheckOutDate.zoneName,
+            timestampCheckIn: zonedCheckInDateTime.epochMilliseconds,
+            timestampCheckOut: zonedCheckOutDateTime.epochMilliseconds,
+            timeZoneCheckIn: checkInTimeZone,
+            timeZoneCheckOut: checkOutTimeZone,
             phoneNumber,
             notes,
             locationLat: coordinateState.enabled ? coordinateState.lat : null,
@@ -322,31 +369,20 @@ export function AccommodationForm({
     tripId,
     tripEndDateTime,
     tripStartDateTime,
+    tripTimeZone,
     coordinateState,
     checkInDateTime,
     checkOutDateTime,
+    checkInTimeZone,
+    checkOutTimeZone,
   ]);
 
-  const handleTimeZoneCheckInChange = useCallback(
-    (newTimeZone: string) => {
-      if (checkInDateTime) {
-        setCheckInDateTime(
-          checkInDateTime.setZone(newTimeZone, { keepLocalTime: true }),
-        );
-      }
-    },
-    [checkInDateTime],
-  );
-  const handleTimeZoneCheckOutChange = useCallback(
-    (newTimeZone: string) => {
-      if (checkOutDateTime) {
-        setCheckOutDateTime(
-          checkOutDateTime.setZone(newTimeZone, { keepLocalTime: true }),
-        );
-      }
-    },
-    [checkOutDateTime],
-  );
+  const handleTimeZoneCheckInChange = useCallback((newTimeZone: string) => {
+    setCheckInTimeZone(newTimeZone);
+  }, []);
+  const handleTimeZoneCheckOutChange = useCallback((newTimeZone: string) => {
+    setCheckOutTimeZone(newTimeZone);
+  }, []);
 
   const onFormInput = useCallback(() => {
     setErrorMessage('');
@@ -426,14 +462,14 @@ export function AccommodationForm({
         <TimeZoneSelect
           id="timeZoneCheckIn"
           name="timeZoneCheckIn"
-          value={checkInDateTime?.zoneName ?? tripTimeZone}
+          value={checkInTimeZone}
           handleChange={handleTimeZoneCheckInChange}
           isFormLoading={false}
         />
         <Text as="label">
           Check in time{' '}
           <Text weight="light" size="1">
-            (required; in {checkInDateTime?.zoneName ?? tripTimeZone} time zone)
+            (required; in {checkInTimeZone} time zone)
           </Text>
         </Text>
         <DateTimePicker
@@ -445,8 +481,8 @@ export function AccommodationForm({
           aria-label="Accommodation check in time"
           placeholder="Select check in time"
           // Buffer one day before and after trip start/end date to allow some flexibility
-          min={tripStartDateTime?.minus({ days: 1 })}
-          max={tripEndDateTime?.plus({ days: 1 })}
+          min={tripStartDateTime?.subtract({ days: 1 })}
+          max={tripEndDateTime?.add({ days: 1 })}
         />
         <Text as="label">
           Check out time zone{' '}
@@ -457,15 +493,14 @@ export function AccommodationForm({
         <TimeZoneSelect
           id="timeZoneCheckOut"
           name="timeZoneCheckOut"
-          value={checkOutDateTime?.zoneName ?? tripTimeZone}
+          value={checkOutTimeZone}
           handleChange={handleTimeZoneCheckOutChange}
           isFormLoading={false}
         />
         <Text as="label">
           Check out time{' '}
           <Text weight="light" size="1">
-            (required; in {checkOutDateTime?.zoneName ?? tripTimeZone} time
-            zone)
+            (required; in {checkOutTimeZone} time zone)
           </Text>
         </Text>
         <DateTimePicker
@@ -477,8 +512,8 @@ export function AccommodationForm({
           aria-label="Accommodation check out time"
           placeholder="Select check out time"
           // Buffer one day before and after trip start/end date to allow some flexibility
-          min={tripStartDateTime?.minus({ days: 1 })}
-          max={tripEndDateTime?.plus({ days: 1 })}
+          min={tripStartDateTime?.subtract({ days: 1 })}
+          max={tripEndDateTime?.add({ days: 1 })}
         />
         <Text as="label" htmlFor={idPhoneNumber}>
           Phone number

--- a/src/Accommodation/AccommodationNewDialog.tsx
+++ b/src/Accommodation/AccommodationNewDialog.tsx
@@ -1,5 +1,4 @@
 import { Box, Dialog } from '@radix-ui/themes';
-import { DateTime } from 'luxon';
 import { useMemo } from 'react';
 import { CommonLargeDialogMaxWidth } from '../Dialog/ui';
 import { useBoundStore } from '../data/store';
@@ -17,47 +16,65 @@ export function AccommodationNewDialog({
   };
 }) {
   const popDialog = useBoundStore((state) => state.popDialog);
-  const tripStartDateTime = DateTime.fromMillis(trip.timestampStart).setZone(
-    trip.timeZone,
-  );
-  const tripEndDateTime = DateTime.fromMillis(trip.timestampEnd)
-    .setZone(trip.timeZone)
-    .minus({ minute: 1 });
+  const tripStartDateTime = Temporal.Instant.fromEpochMilliseconds(
+    trip.timestampStart,
+  )
+    .toZonedDateTimeISO(trip.timeZone)
+    .toPlainDate();
+  const tripEndDateTime = Temporal.Instant.fromEpochMilliseconds(
+    trip.timestampEnd,
+  )
+    .toZonedDateTimeISO(trip.timeZone)
+    .toPlainDate()
+    .subtract({ days: 1 });
 
-  const [accommodationCheckInDateTime, accommodationCheckOutDateTime] =
-    useMemo(() => {
-      if (prefillData) {
-        // Calculate the start of the selected day
-        const tripStart = DateTime.fromMillis(trip.timestampStart).setZone(
-          trip.timeZone,
-        );
-        const selectedDay = tripStart
-          .plus({ days: prefillData.dayOfTrip - 1 })
-          .startOf('day');
+  const [
+    accommodationCheckInDateTime,
+    accommodationCheckOutDateTime,
+    accommodationCheckInTimeZone,
+    accommodationCheckOutTimeZone,
+  ] = useMemo(() => {
+    if (prefillData) {
+      // Calculate the start of the selected day
+      const tripStart = Temporal.Instant.fromEpochMilliseconds(
+        trip.timestampStart,
+      ).toZonedDateTimeISO(trip.timeZone);
+      const selectedDay = tripStart
+        .add({ days: prefillData.dayOfTrip - 1 })
+        .startOfDay();
 
-        // Set check-in to 3pm on the selected day
-        const checkInTime = selectedDay.set({ hour: 15 });
-        // Set check-out to 11am the next day
-        const checkOutTime = selectedDay.plus({ days: 1 }).set({ hour: 11 });
+      // Set check-in to 3pm on the selected day
+      const checkInTime = selectedDay.with({ hour: 15 });
+      // Set check-out to 11am the next day
+      const checkOutTime = selectedDay.add({ days: 1 }).with({ hour: 11 });
 
-        return [checkInTime, checkOutTime];
-      }
-
-      // Default behavior when no prefillData
       return [
-        DateTime.fromMillis(trip.timestampStart)
-          .setZone(trip.timeZone)
-          // Usually check-in is 3pm of the first day
-          .plus({ hour: 15 }),
-        DateTime.fromMillis(trip.timestampEnd)
-          .setZone(trip.timeZone)
-          .minus({
-            day: 1,
-          })
-          // Usually check-out is 11am of the last day
-          .plus({ hour: 11 }),
+        checkInTime.toPlainDateTime(),
+        checkOutTime.toPlainDateTime(),
+        checkInTime.timeZoneId,
+        checkOutTime.timeZoneId,
       ];
-    }, [trip, prefillData]);
+    }
+
+    // Default behavior when no prefillData
+    return [
+      Temporal.Instant.fromEpochMilliseconds(trip.timestampStart)
+        .toZonedDateTimeISO(trip.timeZone)
+        // Usually check-in is 3pm of the first day
+        .with({ hour: 15 })
+        .toPlainDateTime(),
+      Temporal.Instant.fromEpochMilliseconds(trip.timestampEnd)
+        .toZonedDateTimeISO(trip.timeZone)
+        .subtract({
+          days: 1,
+        })
+        // Usually check-out is 11am of the last day
+        .with({ hour: 11 })
+        .toPlainDateTime(),
+      trip.timeZone,
+      trip.timeZone,
+    ];
+  }, [trip, prefillData]);
 
   return (
     <Dialog.Root open>
@@ -78,6 +95,8 @@ export function AccommodationNewDialog({
           accommodationAddress=""
           accommodationCheckInDateTime={accommodationCheckInDateTime}
           accommodationCheckOutDateTime={accommodationCheckOutDateTime}
+          accommodationCheckInTimeZone={accommodationCheckInTimeZone}
+          accommodationCheckOutTimeZone={accommodationCheckOutTimeZone}
           accommodationPhoneNumber=""
           accommodationNotes=""
           accommodationLocationLat={undefined}

--- a/src/Activity/ActivityDialog/ActivityDialogContentEdit.tsx
+++ b/src/Activity/ActivityDialog/ActivityDialogContentEdit.tsx
@@ -1,5 +1,4 @@
 import { Box, Dialog, RadioCards, Spinner, Text } from '@radix-ui/themes';
-import { DateTime } from 'luxon';
 import { useCallback, useEffect, useId, useState } from 'react';
 import type { DialogContentProps } from '../../Dialog/DialogRoute';
 import { useTrip } from '../../Trip/store/hooks';
@@ -28,25 +27,28 @@ export function ActivityDialogContentEdit({
 
   const tripStartDateTime =
     activity && trip
-      ? DateTime.fromMillis(trip.timestampStart).setZone(trip.timeZone)
+      ? Temporal.Instant.fromEpochMilliseconds(trip.timestampStart)
+          .toZonedDateTimeISO(trip.timeZone)
+          .toPlainDate()
       : undefined;
   const tripEndDateTime =
     activity && trip
-      ? DateTime.fromMillis(trip.timestampEnd)
-          .setZone(trip.timeZone)
-          .minus({ minute: 1 })
+      ? Temporal.Instant.fromEpochMilliseconds(trip.timestampEnd)
+          .toZonedDateTimeISO(trip.timeZone)
+          .toPlainDate()
+          .subtract({ days: 1 })
       : undefined;
   const activityStartDateTime =
     activity && trip && activity.timestampStart != null
-      ? DateTime.fromMillis(activity.timestampStart).setZone(
-          activity.timeZoneStart ?? trip.timeZone,
-        )
+      ? Temporal.Instant.fromEpochMilliseconds(activity.timestampStart)
+          .toZonedDateTimeISO(activity.timeZoneStart ?? trip.timeZone)
+          .toPlainDateTime()
       : undefined;
   const activityEndDateTime =
     activity && trip && activity.timestampEnd != null
-      ? DateTime.fromMillis(activity.timestampEnd).setZone(
-          activity.timeZoneEnd ?? trip.timeZone,
-        )
+      ? Temporal.Instant.fromEpochMilliseconds(activity.timestampEnd)
+          .toZonedDateTimeISO(activity.timeZoneEnd ?? trip.timeZone)
+          .toPlainDateTime()
       : undefined;
   const backToViewMode = useCallback(() => {
     setMode(ActivityDialogMode.View);
@@ -85,6 +87,8 @@ export function ActivityDialogContentEdit({
     activityIcon: activity?.icon,
     activityStartDateTime,
     activityEndDateTime,
+    activityStartTimeZone: activity?.timeZoneStart ?? trip?.timeZone,
+    activityEndTimeZone: activity?.timeZoneEnd ?? trip?.timeZone,
     activityLocationLat: activity?.locationLat,
     activityLocationLng: activity?.locationLng,
     activityLocationZoom: activity?.locationZoom,

--- a/src/Activity/ActivityForm/ActivityForm.test.tsx
+++ b/src/Activity/ActivityForm/ActivityForm.test.tsx
@@ -1,7 +1,6 @@
 import { Theme } from '@radix-ui/themes';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { DateTime } from 'luxon';
 import type { ReactElement, ReactNode } from 'react';
 import { describe, expect, test, vi } from 'vitest';
 import { ActivityFlag } from '../activityFlag';
@@ -43,13 +42,15 @@ describe('ActivityForm - TimeZone and DateTimePicker Integration', () => {
   const baseProps = {
     mode: ActivityFormMode.New,
     tripId: 'trip-1',
-    tripStartDateTime: DateTime.fromISO('2024-09-23T00:00:00Z'),
-    tripEndDateTime: DateTime.fromISO('2024-09-25T23:59:59Z'),
+    tripStartDateTime: Temporal.PlainDate.from('2024-09-23T00:00:00'),
+    tripEndDateTime: Temporal.PlainDate.from('2024-09-25T23:59:59'),
     tripTimeZone: 'UTC',
     tripRegion: 'US',
     activityTitle: '',
     activityStartDateTime: undefined,
     activityEndDateTime: undefined,
+    activityStartTimeZone: 'UTC',
+    activityEndTimeZone: 'UTC',
     activityLocation: '',
     activityLocationLat: null,
     activityLocationLng: null,
@@ -66,9 +67,7 @@ describe('ActivityForm - TimeZone and DateTimePicker Integration', () => {
 
   test('changing start time zone preserves local time', async () => {
     const user = userEvent.setup();
-    const initialDateTime = DateTime.fromISO('2024-09-23T14:30:00', {
-      zone: 'UTC',
-    });
+    const initialDateTime = Temporal.PlainDateTime.from('2024-09-23T14:30:00');
 
     renderWithTheme(
       <ActivityForm {...baseProps} activityStartDateTime={initialDateTime} />,
@@ -100,12 +99,12 @@ describe('ActivityForm - TimeZone and DateTimePicker Integration', () => {
 
   test('changing end time zone preserves local time', async () => {
     const user = userEvent.setup();
-    const initialStartDateTime = DateTime.fromISO('2024-09-23T14:30:00', {
-      zone: 'UTC',
-    });
-    const initialEndDateTime = DateTime.fromISO('2024-09-23T16:30:00', {
-      zone: 'UTC',
-    });
+    const initialStartDateTime = Temporal.PlainDateTime.from(
+      '2024-09-23T14:30:00',
+    );
+    const initialEndDateTime = Temporal.PlainDateTime.from(
+      '2024-09-23T16:30:00',
+    );
 
     renderWithTheme(
       <ActivityForm
@@ -136,9 +135,7 @@ describe('ActivityForm - TimeZone and DateTimePicker Integration', () => {
 
   test('clearing datetime works after timezone change', async () => {
     const user = userEvent.setup();
-    const initialDateTime = DateTime.fromISO('2024-09-23T14:30:00', {
-      zone: 'UTC',
-    });
+    const initialDateTime = Temporal.PlainDateTime.from('2024-09-23T14:30:00');
 
     renderWithTheme(
       <ActivityForm {...baseProps} activityStartDateTime={initialDateTime} />,
@@ -179,12 +176,12 @@ describe('ActivityForm - TimeZone and DateTimePicker Integration', () => {
 
   test('timezone changes work independently for start and end times', async () => {
     const user = userEvent.setup();
-    const initialStartDateTime = DateTime.fromISO('2024-09-23T10:00:00', {
-      zone: 'UTC',
-    });
-    const initialEndDateTime = DateTime.fromISO('2024-09-23T18:00:00', {
-      zone: 'UTC',
-    });
+    const initialStartDateTime = Temporal.PlainDateTime.from(
+      '2024-09-23T10:00:00',
+    );
+    const initialEndDateTime = Temporal.PlainDateTime.from(
+      '2024-09-23T18:00:00',
+    );
 
     renderWithTheme(
       <ActivityForm
@@ -257,18 +254,20 @@ describe('ActivityForm - TimeZone and DateTimePicker Integration', () => {
   });
 
   test('clearing start datetime does not affect end datetime timezone', async () => {
-    const initialStartDateTime = DateTime.fromISO('2024-09-23T10:00:00', {
-      zone: 'America/New_York',
-    });
-    const initialEndDateTime = DateTime.fromISO('2024-09-23T18:00:00', {
-      zone: 'America/Los_Angeles',
-    });
+    const initialStartDateTime = Temporal.PlainDateTime.from(
+      '2024-09-23T10:00:00',
+    );
+    const initialEndDateTime = Temporal.PlainDateTime.from(
+      '2024-09-23T18:00:00',
+    );
 
     renderWithTheme(
       <ActivityForm
         {...baseProps}
         activityStartDateTime={initialStartDateTime}
+        activityStartTimeZone="America/New_York"
         activityEndDateTime={initialEndDateTime}
+        activityEndTimeZone="America/Los_Angeles"
       />,
     );
 
@@ -302,8 +301,8 @@ describe('ActivityForm - TimeZone and DateTimePicker Integration', () => {
   });
 
   test('datetime picker respects trip date boundaries with timezone offset', async () => {
-    const tripStart = DateTime.fromISO('2024-09-23T00:00:00Z');
-    const tripEnd = DateTime.fromISO('2024-09-25T23:59:59Z');
+    const tripStart = Temporal.PlainDate.from('2024-09-23T00:00:00');
+    const tripEnd = Temporal.PlainDate.from('2024-09-25T23:59:59');
 
     renderWithTheme(
       <ActivityForm
@@ -324,9 +323,7 @@ describe('ActivityForm - TimeZone and DateTimePicker Integration', () => {
   test('changing timezone does not trigger unnecessary re-renders', async () => {
     const user = userEvent.setup();
     const onFormSuccess = vi.fn();
-    const initialDateTime = DateTime.fromISO('2024-09-23T14:30:00', {
-      zone: 'UTC',
-    });
+    const initialDateTime = Temporal.PlainDateTime.from('2024-09-23T14:30:00');
 
     renderWithTheme(
       <ActivityForm
@@ -401,13 +398,15 @@ describe('ActivityForm - Activity Idea and Time Interaction', () => {
   const baseProps = {
     mode: ActivityFormMode.New,
     tripId: 'trip-1',
-    tripStartDateTime: DateTime.fromISO('2024-09-23T00:00:00Z'),
-    tripEndDateTime: DateTime.fromISO('2024-09-25T23:59:59Z'),
+    tripStartDateTime: Temporal.PlainDate.from('2024-09-23T00:00:00'),
+    tripEndDateTime: Temporal.PlainDate.from('2024-09-25T23:59:59'),
     tripTimeZone: 'UTC',
     tripRegion: 'US',
     activityTitle: '',
     activityStartDateTime: undefined,
     activityEndDateTime: undefined,
+    activityStartTimeZone: 'UTC',
+    activityEndTimeZone: 'UTC',
     activityLocation: '',
     activityLocationLat: null,
     activityLocationLng: null,
@@ -445,12 +444,8 @@ describe('ActivityForm - Activity Idea and Time Interaction', () => {
 
   test('toggling isIdea on preserves existing start/end times', async () => {
     const user = userEvent.setup();
-    const startDateTime = DateTime.fromISO('2024-09-23T10:00:00', {
-      zone: 'UTC',
-    });
-    const endDateTime = DateTime.fromISO('2024-09-23T12:00:00', {
-      zone: 'UTC',
-    });
+    const startDateTime = Temporal.PlainDateTime.from('2024-09-23T10:00:00');
+    const endDateTime = Temporal.PlainDateTime.from('2024-09-23T12:00:00');
 
     renderWithTheme(
       <ActivityForm
@@ -480,12 +475,8 @@ describe('ActivityForm - Activity Idea and Time Interaction', () => {
 
   test('toggling isIdea off preserves existing start/end times', async () => {
     const user = userEvent.setup();
-    const startDateTime = DateTime.fromISO('2024-09-23T14:00:00', {
-      zone: 'UTC',
-    });
-    const endDateTime = DateTime.fromISO('2024-09-23T16:00:00', {
-      zone: 'UTC',
-    });
+    const startDateTime = Temporal.PlainDateTime.from('2024-09-23T14:00:00');
+    const endDateTime = Temporal.PlainDateTime.from('2024-09-23T16:00:00');
 
     renderWithTheme(
       <ActivityForm
@@ -535,12 +526,8 @@ describe('ActivityForm - Activity Idea and Time Interaction', () => {
   });
 
   test('idea activity can have both start and end times set', () => {
-    const startDateTime = DateTime.fromISO('2024-09-23T09:00:00', {
-      zone: 'UTC',
-    });
-    const endDateTime = DateTime.fromISO('2024-09-23T11:00:00', {
-      zone: 'UTC',
-    });
+    const startDateTime = Temporal.PlainDateTime.from('2024-09-23T09:00:00');
+    const endDateTime = Temporal.PlainDateTime.from('2024-09-23T11:00:00');
 
     renderWithTheme(
       <ActivityForm
@@ -562,18 +549,16 @@ describe('ActivityForm - Activity Idea and Time Interaction', () => {
 
   test('toggling isIdea preserves timezone selections', async () => {
     const user = userEvent.setup();
-    const startDateTime = DateTime.fromISO('2024-09-23T10:00:00', {
-      zone: 'America/New_York',
-    });
-    const endDateTime = DateTime.fromISO('2024-09-23T14:00:00', {
-      zone: 'America/Los_Angeles',
-    });
+    const startDateTime = Temporal.PlainDateTime.from('2024-09-23T10:00:00');
+    const endDateTime = Temporal.PlainDateTime.from('2024-09-23T14:00:00');
 
     renderWithTheme(
       <ActivityForm
         {...baseProps}
         activityStartDateTime={startDateTime}
         activityEndDateTime={endDateTime}
+        activityStartTimeZone="America/New_York"
+        activityEndTimeZone="America/Los_Angeles"
         activityFlags={0}
       />,
     );
@@ -606,9 +591,7 @@ describe('ActivityForm - Activity Idea and Time Interaction', () => {
 
   test('changing timezone works when isIdea is checked', async () => {
     const user = userEvent.setup();
-    const startDateTime = DateTime.fromISO('2024-09-23T10:00:00', {
-      zone: 'UTC',
-    });
+    const startDateTime = Temporal.PlainDateTime.from('2024-09-23T10:00:00');
 
     renderWithTheme(
       <ActivityForm
@@ -673,12 +656,8 @@ describe('ActivityForm - Activity Idea and Time Interaction', () => {
   });
 
   test('editing existing idea with times shows correct initial state', () => {
-    const startDateTime = DateTime.fromISO('2024-09-23T08:00:00', {
-      zone: 'Europe/London',
-    });
-    const endDateTime = DateTime.fromISO('2024-09-23T10:00:00', {
-      zone: 'Europe/London',
-    });
+    const startDateTime = Temporal.PlainDateTime.from('2024-09-23T08:00:00');
+    const endDateTime = Temporal.PlainDateTime.from('2024-09-23T10:00:00');
 
     renderWithTheme(
       <ActivityForm
@@ -688,6 +667,8 @@ describe('ActivityForm - Activity Idea and Time Interaction', () => {
         activityTitle="Museum Visit"
         activityStartDateTime={startDateTime}
         activityEndDateTime={endDateTime}
+        activityStartTimeZone="Europe/London"
+        activityEndTimeZone="Europe/London"
         activityFlags={IDEA_FLAG}
       />,
     );
@@ -730,12 +711,8 @@ describe('ActivityForm - Activity Idea and Time Interaction', () => {
 
   test('multiple toggle of isIdea does not affect times', async () => {
     const user = userEvent.setup();
-    const startDateTime = DateTime.fromISO('2024-09-23T15:00:00', {
-      zone: 'UTC',
-    });
-    const endDateTime = DateTime.fromISO('2024-09-23T17:00:00', {
-      zone: 'UTC',
-    });
+    const startDateTime = Temporal.PlainDateTime.from('2024-09-23T15:00:00');
+    const endDateTime = Temporal.PlainDateTime.from('2024-09-23T17:00:00');
 
     renderWithTheme(
       <ActivityForm

--- a/src/Activity/ActivityForm/ActivityForm.tsx
+++ b/src/Activity/ActivityForm/ActivityForm.tsx
@@ -452,7 +452,9 @@ export function ActivityForm({
           tripStartDateTime.toZonedDateTime(tripTimeZone).subtract({ days: 1 }),
         ) < 0
       ) {
-        setErrorMessage('Start time cannot be earlier than trip start time');
+        setErrorMessage(
+          'Start time cannot be earlier than 1 day before trip start',
+        );
         return;
       }
       // end time cannot be later than trip end time + 1d
@@ -464,7 +466,9 @@ export function ActivityForm({
           tripEndDateTime.toZonedDateTime(tripTimeZone).add({ days: 2 }),
         ) > 0
       ) {
-        setErrorMessage('End time cannot be later than trip end time');
+        setErrorMessage(
+          'End time cannot be later than 1 day after trip end time',
+        );
         return;
       }
       if (mode === ActivityFormMode.Edit && activityId) {

--- a/src/Activity/ActivityForm/ActivityForm.tsx
+++ b/src/Activity/ActivityForm/ActivityForm.tsx
@@ -446,7 +446,7 @@ export function ActivityForm({
         timeEndDate &&
         Temporal.ZonedDateTime.compare(
           timeEndDate,
-          tripEndDateTime.toZonedDateTime(tripTimeZone),
+          tripEndDateTime.toZonedDateTime(tripTimeZone).add({ days: 1 }),
         ) > 0
       ) {
         setErrorMessage('End time cannot be later than trip end time');

--- a/src/Activity/ActivityForm/ActivityForm.tsx
+++ b/src/Activity/ActivityForm/ActivityForm.tsx
@@ -126,6 +126,7 @@ export function ActivityForm({
   activityId?: string;
   tripId?: string;
   tripStartDateTime: Temporal.PlainDate | undefined;
+  /** trip's final day */
   tripEndDateTime: Temporal.PlainDate | undefined;
   tripTimeZone: string;
   tripRegion: string;

--- a/src/Activity/ActivityForm/ActivityForm.tsx
+++ b/src/Activity/ActivityForm/ActivityForm.tsx
@@ -428,25 +428,25 @@ export function ActivityForm({
         setErrorMessage('End time must be after start time');
         return;
       }
-      // start time cannot be earlier than trip start time
+      // start time cannot be earlier than trip start time - 1d
       if (
         tripStartDateTime &&
         timeStartDate &&
         Temporal.ZonedDateTime.compare(
           timeStartDate,
-          tripStartDateTime.toZonedDateTime(tripTimeZone),
+          tripStartDateTime.toZonedDateTime(tripTimeZone).subtract({ days: 1 }),
         ) < 0
       ) {
         setErrorMessage('Start time cannot be earlier than trip start time');
         return;
       }
-      // end time cannot be later than trip end time
+      // end time cannot be later than trip end time + 1d
       if (
         tripEndDateTime &&
         timeEndDate &&
         Temporal.ZonedDateTime.compare(
           timeEndDate,
-          tripEndDateTime.toZonedDateTime(tripTimeZone).add({ days: 1 }),
+          tripEndDateTime.toZonedDateTime(tripTimeZone).add({ days: 2 }),
         ) > 0
       ) {
         setErrorMessage('End time cannot be later than trip end time');

--- a/src/Activity/ActivityForm/ActivityForm.tsx
+++ b/src/Activity/ActivityForm/ActivityForm.tsx
@@ -1,5 +1,4 @@
 import { Button, Flex, Switch, Text, TextArea } from '@radix-ui/themes';
-import type { DateTime } from 'luxon';
 import type { SubmitEvent } from 'react';
 import { useCallback, useId, useReducer, useState } from 'react';
 import { DateTimePicker } from '../../common/DatePicker2/DateTimePicker';
@@ -104,6 +103,9 @@ export function ActivityForm({
   activityIcon,
   activityStartDateTime,
   activityEndDateTime,
+  activityStartTimeZone,
+  activityEndTimeZone,
+
   activityLocation,
   activityLocationLng,
   activityLocationLat,
@@ -123,14 +125,17 @@ export function ActivityForm({
   mode: ActivityFormModeType;
   activityId?: string;
   tripId?: string;
-  tripStartDateTime: DateTime | undefined;
-  tripEndDateTime: DateTime | undefined;
+  tripStartDateTime: Temporal.PlainDate | undefined;
+  tripEndDateTime: Temporal.PlainDate | undefined;
   tripTimeZone: string;
   tripRegion: string;
   activityTitle: string;
   activityIcon?: string | null | undefined;
-  activityStartDateTime: DateTime | undefined;
-  activityEndDateTime: DateTime | undefined;
+  activityStartDateTime: Temporal.PlainDateTime | undefined;
+  activityEndDateTime: Temporal.PlainDateTime | undefined;
+  activityStartTimeZone: string | undefined;
+  activityEndTimeZone: string | undefined;
+
   activityLocation: string;
   activityLocationLat: number | null | undefined;
   activityLocationLng: number | null | undefined;
@@ -170,18 +175,18 @@ export function ActivityForm({
   });
 
   // State for DateTime pickers
-  const [startDateTime, setStartDateTime] = useState<DateTime | undefined>(
-    activityStartDateTime,
-  );
-  const [endDateTime, setEndDateTime] = useState<DateTime | undefined>(
-    activityEndDateTime,
-  );
+  const [startDateTime, setStartDateTime] = useState<
+    Temporal.PlainDateTime | undefined
+  >(activityStartDateTime);
+  const [endDateTime, setEndDateTime] = useState<
+    Temporal.PlainDateTime | undefined
+  >(activityEndDateTime);
 
   const [startTimeZone, setStartTimeZone] = useState<string>(
-    activityStartDateTime?.zoneName ?? tripTimeZone,
+    activityStartTimeZone ?? tripTimeZone,
   );
   const [endTimeZone, setEndTimeZone] = useState<string>(
-    activityEndDateTime?.zoneName ?? tripTimeZone,
+    activityEndTimeZone ?? tripTimeZone,
   );
 
   const [locationFieldsState, dispatchLocationFieldsState] = useReducer(
@@ -337,58 +342,38 @@ export function ActivityForm({
     }
   }, []);
 
-  const handleTimeZoneStartChange = useCallback(
-    (newTimeZone: string) => {
-      setStartTimeZone(newTimeZone);
-      if (startDateTime) {
-        setStartDateTime(
-          startDateTime.setZone(newTimeZone, { keepLocalTime: true }),
-        );
-      }
-    },
-    [startDateTime],
-  );
+  const handleTimeZoneStartChange = useCallback((newTimeZone: string) => {
+    setStartTimeZone(newTimeZone);
+  }, []);
 
-  const handleTimeZoneEndChange = useCallback(
-    (newTimeZone: string) => {
-      setEndTimeZone(newTimeZone);
-      if (endDateTime) {
-        setEndDateTime(
-          endDateTime.setZone(newTimeZone, { keepLocalTime: true }),
-        );
-      }
-    },
-    [endDateTime],
-  );
+  const handleTimeZoneEndChange = useCallback((newTimeZone: string) => {
+    setEndTimeZone(newTimeZone);
+  }, []);
 
-  // Wrapper for start datetime changes that applies the selected timezone
   const handleStartDateTimeChange = useCallback(
-    (newDateTime: DateTime | undefined) => {
-      if (newDateTime) {
-        // Apply the selected timezone to the new datetime
-        setStartDateTime(
-          newDateTime.setZone(startTimeZone, { keepLocalTime: true }),
-        );
+    (newDateTime: Temporal.PlainDate | Temporal.PlainDateTime | undefined) => {
+      if (newDateTime instanceof Temporal.PlainDateTime) {
+        setStartDateTime(newDateTime);
+      } else if (newDateTime instanceof Temporal.PlainDate) {
+        setStartDateTime(newDateTime.toPlainDateTime({ hour: 0, minute: 0 }));
       } else {
         setStartDateTime(undefined);
       }
     },
-    [startTimeZone],
+    [],
   );
 
-  // Wrapper for end datetime changes that applies the selected timezone
   const handleEndDateTimeChange = useCallback(
-    (newDateTime: DateTime | undefined) => {
-      if (newDateTime) {
-        // Apply the selected timezone to the new datetime
-        setEndDateTime(
-          newDateTime.setZone(endTimeZone, { keepLocalTime: true }),
-        );
+    (newDateTime: Temporal.PlainDate | Temporal.PlainDateTime | undefined) => {
+      if (newDateTime instanceof Temporal.PlainDateTime) {
+        setEndDateTime(newDateTime);
+      } else if (newDateTime instanceof Temporal.PlainDate) {
+        setEndDateTime(newDateTime.toPlainDateTime({ hour: 0, minute: 0 }));
       } else {
         setEndDateTime(undefined);
       }
     },
-    [endTimeZone],
+    [],
   );
 
   const handleSubmit = useCallback(() => {
@@ -408,8 +393,8 @@ export function ActivityForm({
       const location = (formData.get('location') as string | null) ?? '';
       const locationDestination =
         (formData.get('locationDestination') as string | null) ?? '';
-      const timeStartDate = startDateTime;
-      const timeEndDate = endDateTime;
+      const timeStartDate = startDateTime?.toZonedDateTime(startTimeZone);
+      const timeEndDate = endDateTime?.toZonedDateTime(endTimeZone);
       const flags = updateActivityFlag(
         activityFlags,
         ActivityFlag.IsIdea,
@@ -437,7 +422,7 @@ export function ActivityForm({
       if (
         timeEndDate &&
         timeStartDate &&
-        timeEndDate.diff(timeStartDate).as('minute') < 0
+        Temporal.ZonedDateTime.compare(timeStartDate, timeEndDate) > 0
       ) {
         setErrorMessage('End time must be after start time');
         return;
@@ -446,13 +431,23 @@ export function ActivityForm({
       if (
         tripStartDateTime &&
         timeStartDate &&
-        timeStartDate < tripStartDateTime
+        Temporal.ZonedDateTime.compare(
+          timeStartDate,
+          tripStartDateTime.toZonedDateTime(tripTimeZone),
+        ) < 0
       ) {
         setErrorMessage('Start time cannot be earlier than trip start time');
         return;
       }
       // end time cannot be later than trip end time
-      if (tripEndDateTime && timeEndDate && timeEndDate > tripEndDateTime) {
+      if (
+        tripEndDateTime &&
+        timeEndDate &&
+        Temporal.ZonedDateTime.compare(
+          timeEndDate,
+          tripEndDateTime.toZonedDateTime(tripTimeZone),
+        ) > 0
+      ) {
         setErrorMessage('End time cannot be later than trip end time');
         return;
       }
@@ -487,10 +482,12 @@ export function ActivityForm({
               ? locationFieldsState.zoom[1]
               : null,
 
-          timestampStart: timeStartDate ? timeStartDate.toMillis() : null,
-          timestampEnd: timeEndDate ? timeEndDate.toMillis() : null,
-          timeZoneStart: timeStartDate ? timeStartDate.zoneName : null,
-          timeZoneEnd: timeEndDate ? timeEndDate.zoneName : null,
+          timestampStart: timeStartDate
+            ? timeStartDate.epochMilliseconds
+            : null,
+          timestampEnd: timeEndDate ? timeEndDate.epochMilliseconds : null,
+          timeZoneStart: timeStartDate ? timeStartDate.timeZoneId : null,
+          timeZoneEnd: timeEndDate ? timeEndDate.timeZoneId : null,
           flags: flags,
         });
         publishToast({
@@ -500,8 +497,9 @@ export function ActivityForm({
         });
       } else if (mode === ActivityFormMode.New && tripId) {
         if (timeEndDate) {
+          // So that when next time user open the form, it prefill the start time with the last end time of this activity
           setTripLocalState(tripId, {
-            activityTimestampStart: timeEndDate.toMillis(),
+            activityTimestampStart: timeEndDate.epochMilliseconds,
           });
         }
         await dbAddActivity(
@@ -532,10 +530,12 @@ export function ActivityForm({
               locationFieldsState.enabled[1] && locationFieldsState.count === 2
                 ? locationFieldsState.zoom[1]
                 : null,
-            timestampStart: timeStartDate ? timeStartDate.toMillis() : null,
-            timestampEnd: timeEndDate ? timeEndDate.toMillis() : null,
-            timeZoneStart: timeStartDate ? timeStartDate.zoneName : null,
-            timeZoneEnd: timeEndDate ? timeEndDate.zoneName : null,
+            timestampStart: timeStartDate
+              ? timeStartDate.epochMilliseconds
+              : null,
+            timestampEnd: timeEndDate ? timeEndDate.epochMilliseconds : null,
+            timeZoneStart: timeStartDate ? timeStartDate.timeZoneId : null,
+            timeZoneEnd: timeEndDate ? timeEndDate.timeZoneId : null,
             flags: flags,
           },
           {
@@ -554,12 +554,14 @@ export function ActivityForm({
     };
   }, [
     activityId,
-    endDateTime,
     locationFieldsState,
     mode,
     onFormSuccess,
     publishToast,
     startDateTime,
+    endDateTime,
+    startTimeZone,
+    endTimeZone,
     isIdea,
     tripId,
     tripTimeZone,
@@ -734,8 +736,8 @@ export function ActivityForm({
           name="startTime"
           mode={DateTimePickerMode.DateTime}
           // Buffer one day before and after trip start/end date to allow some flexibility
-          min={tripStartDateTime?.minus({ days: 1 })}
-          max={tripEndDateTime?.plus({ days: 1 })}
+          min={tripStartDateTime?.subtract({ days: 1 })}
+          max={tripEndDateTime?.add({ days: 1 })}
           value={startDateTime}
           onChange={handleStartDateTimeChange}
           clearable={true}
@@ -763,8 +765,8 @@ export function ActivityForm({
           name="endTime"
           mode={DateTimePickerMode.DateTime}
           // Buffer one day before and after trip start/end date to allow some flexibility
-          min={tripStartDateTime?.minus({ days: 1 })}
-          max={tripEndDateTime?.plus({ days: 1 })}
+          min={tripStartDateTime?.subtract({ days: 1 })}
+          max={tripEndDateTime?.add({ days: 1 })}
           value={endDateTime}
           onChange={handleEndDateTimeChange}
           clearable={true}

--- a/src/Activity/ActivityForm/ActivityForm.tsx
+++ b/src/Activity/ActivityForm/ActivityForm.tsx
@@ -352,16 +352,31 @@ export function ActivityForm({
   }, []);
 
   const handleStartDateTimeChange = useCallback(
-    (newDateTime: Temporal.PlainDate | Temporal.PlainDateTime | undefined) => {
-      if (newDateTime instanceof Temporal.PlainDateTime) {
-        setStartDateTime(newDateTime);
-      } else if (newDateTime instanceof Temporal.PlainDate) {
-        setStartDateTime(newDateTime.toPlainDateTime({ hour: 0, minute: 0 }));
-      } else {
-        setStartDateTime(undefined);
+    (
+      newDateTimeMaybe: Temporal.PlainDate | Temporal.PlainDateTime | undefined,
+    ) => {
+      const newDateTime =
+        newDateTimeMaybe instanceof Temporal.PlainDateTime
+          ? newDateTimeMaybe
+          : newDateTimeMaybe instanceof Temporal.PlainDate
+            ? newDateTimeMaybe.toPlainDateTime({ hour: 0, minute: 0 })
+            : undefined;
+      setStartDateTime(newDateTime);
+
+      // If start time is changed, should try to preserve the duration of activity by adjusting the end time accordingly, if end time is set. If end time is before new start time, clear the end time
+      if (startDateTime && endDateTime && newDateTime) {
+        const duration = startDateTime.until(endDateTime, {
+          largestUnit: 'seconds',
+        });
+        const newEndDateTime = newDateTime.add(duration);
+        if (Temporal.PlainDateTime.compare(newEndDateTime, newDateTime) > 0) {
+          setEndDateTime(newEndDateTime);
+        } else {
+          setEndDateTime(undefined);
+        }
       }
     },
-    [],
+    [startDateTime, endDateTime],
   );
 
   const handleEndDateTimeChange = useCallback(

--- a/src/Activity/ActivityNewDialog.tsx
+++ b/src/Activity/ActivityNewDialog.tsx
@@ -1,5 +1,4 @@
 import { Box, Dialog } from '@radix-ui/themes';
-import { DateTime } from 'luxon';
 import { useMemo } from 'react';
 import { CommonLargeDialogMaxWidth } from '../Dialog/ui';
 import { useBoundStore } from '../data/store';
@@ -20,43 +19,65 @@ export function ActivityNewDialog({
 }) {
   const localState = useTripLocalState(trip.id);
   const popDialog = useBoundStore((state) => state.popDialog);
-  const tripStartDateTime = DateTime.fromMillis(trip.timestampStart).setZone(
-    trip.timeZone,
-  );
-  const tripEndDateTime = DateTime.fromMillis(trip.timestampEnd)
-    .setZone(trip.timeZone)
-    .minus({ minute: 1 });
-  const [activityStartDateTime, activityEndDateTime] = useMemo(() => {
+
+  const tripStartDateTime = Temporal.Instant.fromEpochMilliseconds(
+    trip.timestampStart,
+  )
+    .toZonedDateTimeISO(trip.timeZone)
+    .toPlainDate();
+  const tripEndDateTime = Temporal.Instant.fromEpochMilliseconds(
+    trip.timestampEnd,
+  )
+    .toZonedDateTimeISO(trip.timeZone)
+    .toPlainDate()
+    .subtract({ days: 1 });
+
+  const [
+    activityStartDateTime,
+    activityEndDateTime,
+    activityStartTimeZone,
+    activityEndTimeZone,
+  ] = useMemo(() => {
     if (prefillData) {
       // Convert timeStart (HHMM format) to DateTime
       const hours = parseInt(prefillData.timeStart.substring(0, 2), 10);
       const minutes = parseInt(prefillData.timeStart.substring(2, 4), 10);
 
       // Calculate the start of the selected day
-      const tripStart = DateTime.fromMillis(trip.timestampStart).setZone(
-        trip.timeZone,
-      );
+      const tripStart = Temporal.Instant.fromEpochMilliseconds(
+        trip.timestampStart,
+      ).toZonedDateTimeISO(trip.timeZone);
       const activityDay = tripStart
-        .plus({ days: prefillData.dayOfTrip - 1 })
-        .startOf('day');
+        .add({ days: prefillData.dayOfTrip - 1 })
+        .startOfDay();
 
       // Set the specific time on that day
-      const activityStartTime = activityDay.set({
+      const activityStartZonedTime = activityDay.with({
         hour: hours,
         minute: minutes,
       });
-      const activityEndTime = activityStartTime.plus({ hours: 1 });
+      const activityEndZonedTime = activityStartZonedTime.add({ hours: 1 });
 
-      return [activityStartTime, activityEndTime];
+      return [
+        activityStartZonedTime.toPlainDateTime(),
+        activityEndZonedTime.toPlainDateTime(),
+        activityStartZonedTime.timeZoneId,
+        activityEndZonedTime.timeZoneId,
+      ];
     }
 
     // Default behavior when no prefillData
-    const activityStartTime = DateTime.fromMillis(
+    const activityStartZonedTime = Temporal.Instant.fromEpochMilliseconds(
       localState?.activityTimestampStart ?? trip.timestampStart,
-    ).setZone(trip.timeZone);
-    const activityEndTime = activityStartTime.plus({ hours: 1 });
+    ).toZonedDateTimeISO(trip.timeZone);
+    const activityEndZonedTime = activityStartZonedTime.add({ hours: 1 });
 
-    return [activityStartTime, activityEndTime];
+    return [
+      activityStartZonedTime.toPlainDateTime(),
+      activityEndZonedTime.toPlainDateTime(),
+      activityStartZonedTime.timeZoneId,
+      activityEndZonedTime.timeZoneId,
+    ];
   }, [trip, prefillData, localState?.activityTimestampStart]);
 
   return (
@@ -78,6 +99,8 @@ export function ActivityNewDialog({
           activityIcon={undefined}
           activityStartDateTime={activityStartDateTime}
           activityEndDateTime={activityEndDateTime}
+          activityStartTimeZone={activityStartTimeZone}
+          activityEndTimeZone={activityEndTimeZone}
           activityLocation={''}
           activityDescription={''}
           activityLocationLat={undefined}

--- a/src/Activity/FlightForm/FlightForm.tsx
+++ b/src/Activity/FlightForm/FlightForm.tsx
@@ -6,7 +6,6 @@ import {
   TextArea,
   TextField,
 } from '@radix-ui/themes';
-import type { DateTime } from 'luxon';
 import type { SubmitEvent } from 'react';
 import { useCallback, useId, useReducer, useState } from 'react';
 import { DateTimePicker } from '../../common/DatePicker2/DateTimePicker';
@@ -28,10 +27,6 @@ import {
 } from '../activityFlag';
 import { dbAddActivity, dbUpdateActivity } from '../db';
 import { airportGeocodingRequest } from './FlightFormGeocoding';
-import {
-  temporalToLuxonDate,
-  temporalToLuxonDateTime,
-} from '../../common/dateTime/luxonTemporalConverter';
 
 interface LocationCoordinateState {
   enabled: [boolean, boolean];
@@ -95,6 +90,8 @@ export function FlightForm({
   activityIcon,
   activityStartDateTime,
   activityEndDateTime,
+  activityStartTimeZone,
+  activityEndTimeZone,
   activityLocation,
   activityLocationLng,
   activityLocationLat,
@@ -117,8 +114,10 @@ export function FlightForm({
   tripRegion: string;
   activityTitle: string;
   activityIcon?: string | null | undefined;
-  activityStartDateTime: DateTime | undefined;
-  activityEndDateTime: DateTime | undefined;
+  activityStartDateTime: Temporal.PlainDateTime | undefined;
+  activityEndDateTime: Temporal.PlainDateTime | undefined;
+  activityStartTimeZone: string | undefined;
+  activityEndTimeZone: string | undefined;
   activityLocation: string;
   activityLocationLat: number | null | undefined;
   activityLocationLng: number | null | undefined;
@@ -151,17 +150,17 @@ export function FlightForm({
     hasActivityFlag(activityFlags, ActivityFlag.IsIdea),
   );
 
-  const [startDateTime, setStartDateTime] = useState<DateTime | undefined>(
-    activityStartDateTime,
-  );
-  const [endDateTime, setEndDateTime] = useState<DateTime | undefined>(
-    activityEndDateTime,
-  );
+  const [startDateTime, setStartDateTime] = useState<
+    Temporal.PlainDateTime | undefined
+  >(activityStartDateTime);
+  const [endDateTime, setEndDateTime] = useState<
+    Temporal.PlainDateTime | undefined
+  >(activityEndDateTime);
   const [startTimeZone, setStartTimeZone] = useState<string>(
-    activityStartDateTime?.zoneName ?? tripTimeZone,
+    activityStartTimeZone ?? tripTimeZone,
   );
   const [endTimeZone, setEndTimeZone] = useState<string>(
-    activityEndDateTime?.zoneName ?? tripTimeZone,
+    activityEndTimeZone ?? tripTimeZone,
   );
 
   const [locationFieldsState, dispatchLocationFieldsState] = useReducer(
@@ -279,47 +278,35 @@ export function FlightForm({
     dispatchLocationFieldsState({ type: 'setMapZoom', index: 1, zoom });
   }, []);
 
-  const handleTimeZoneStartChange = useCallback(
-    (newTimeZone: string) => {
-      setStartTimeZone(newTimeZone);
-      if (startDateTime) {
-        setStartDateTime(
-          startDateTime.setZone(newTimeZone, { keepLocalTime: true }),
-        );
-      }
-    },
-    [startDateTime],
-  );
-  const handleTimeZoneEndChange = useCallback(
-    (newTimeZone: string) => {
-      setEndTimeZone(newTimeZone);
-      if (endDateTime) {
-        setEndDateTime(
-          endDateTime.setZone(newTimeZone, { keepLocalTime: true }),
-        );
-      }
-    },
-    [endDateTime],
-  );
+  const handleTimeZoneStartChange = useCallback((newTimeZone: string) => {
+    setStartTimeZone(newTimeZone);
+  }, []);
+  const handleTimeZoneEndChange = useCallback((newTimeZone: string) => {
+    setEndTimeZone(newTimeZone);
+  }, []);
   const handleStartDateTimeChange = useCallback(
-    (newDateTime: DateTime | undefined) => {
-      setStartDateTime(
-        newDateTime
-          ? newDateTime.setZone(startTimeZone, { keepLocalTime: true })
-          : undefined,
-      );
+    (newDateTime: Temporal.PlainDateTime | Temporal.PlainDate | undefined) => {
+      if (newDateTime instanceof Temporal.PlainDateTime) {
+        setStartDateTime(newDateTime);
+      } else if (newDateTime instanceof Temporal.PlainDate) {
+        setStartDateTime(newDateTime.toPlainDateTime({ hour: 0, minute: 0 }));
+      } else {
+        setStartDateTime(undefined);
+      }
     },
-    [startTimeZone],
+    [],
   );
   const handleEndDateTimeChange = useCallback(
-    (newDateTime: DateTime | undefined) => {
-      setEndDateTime(
-        newDateTime
-          ? newDateTime.setZone(endTimeZone, { keepLocalTime: true })
-          : undefined,
-      );
+    (newDateTime: Temporal.PlainDateTime | Temporal.PlainDate | undefined) => {
+      if (newDateTime instanceof Temporal.PlainDateTime) {
+        setEndDateTime(newDateTime);
+      } else if (newDateTime instanceof Temporal.PlainDate) {
+        setEndDateTime(newDateTime.toPlainDateTime({ hour: 0, minute: 0 }));
+      } else {
+        setEndDateTime(undefined);
+      }
     },
-    [endTimeZone],
+    [],
   );
 
   const handleSubmit = useCallback(() => {
@@ -334,6 +321,8 @@ export function FlightForm({
       const description = (formData.get('description') as string | null) ?? '';
       const from = (formData.get('from') as string | null) ?? '';
       const to = (formData.get('to') as string | null) ?? '';
+      const startZonedDateTime = startDateTime?.toZonedDateTime(startTimeZone);
+      const endZonedDateTime = endDateTime?.toZonedDateTime(endTimeZone);
 
       if (!title) return;
       if (!from) {
@@ -345,21 +334,20 @@ export function FlightForm({
         return;
       }
       if (
-        endDateTime &&
-        startDateTime &&
-        endDateTime.diff(startDateTime).as('minute') < 0
+        startZonedDateTime &&
+        endZonedDateTime &&
+        Temporal.ZonedDateTime.compare(startZonedDateTime, endZonedDateTime) > 0
       ) {
         setErrorMessage('Arrival time must be after departure time');
         return;
       }
       if (
         tripStartDateTime &&
-        startDateTime &&
-        startDateTime <
-          temporalToLuxonDate(
-            tripStartDateTime.subtract({ days: 1 }),
-            tripTimeZone,
-          )
+        startZonedDateTime &&
+        Temporal.ZonedDateTime.compare(
+          tripStartDateTime.subtract({ days: 1 }).toZonedDateTime(tripTimeZone),
+          startZonedDateTime,
+        ) > 0
       ) {
         setErrorMessage(
           'Departure time cannot be earlier than 1 day before trip start',
@@ -368,12 +356,11 @@ export function FlightForm({
       }
       if (
         tripEndDateTime &&
-        endDateTime &&
-        endDateTime >
-          temporalToLuxonDate(
-            tripEndDateTime.add({ days: 1 }),
-            tripTimeZone,
-          )
+        endZonedDateTime &&
+        Temporal.ZonedDateTime.compare(
+          endZonedDateTime,
+          tripEndDateTime.add({ days: 1 }).toZonedDateTime(tripTimeZone),
+        ) > 0
       ) {
         setErrorMessage(
           'Arrival time cannot be later than 1 day after trip end',
@@ -411,10 +398,16 @@ export function FlightForm({
           locationDestinationZoom: locationFieldsState.enabled[1]
             ? locationFieldsState.zoom[1]
             : null,
-          timestampStart: startDateTime ? startDateTime.toMillis() : null,
-          timestampEnd: endDateTime ? endDateTime.toMillis() : null,
-          timeZoneStart: startDateTime ? startDateTime.zoneName : null,
-          timeZoneEnd: endDateTime ? endDateTime.zoneName : null,
+          timestampStart: startZonedDateTime
+            ? startZonedDateTime.epochMilliseconds
+            : null,
+          timestampEnd: endZonedDateTime
+            ? endZonedDateTime.epochMilliseconds
+            : null,
+          timeZoneStart: startZonedDateTime
+            ? startZonedDateTime.timeZoneId
+            : null,
+          timeZoneEnd: endZonedDateTime ? endZonedDateTime.timeZoneId : null,
           flags,
         });
         publishToast({
@@ -423,9 +416,9 @@ export function FlightForm({
           close: {},
         });
       } else if (mode === ActivityFormMode.New && tripId) {
-        if (endDateTime) {
+        if (endZonedDateTime) {
           setTripLocalState(tripId, {
-            activityTimestampStart: endDateTime.toMillis(),
+            activityTimestampStart: endZonedDateTime.epochMilliseconds,
           });
         }
         await dbAddActivity(
@@ -453,10 +446,17 @@ export function FlightForm({
             locationDestinationZoom: locationFieldsState.enabled[1]
               ? locationFieldsState.zoom[1]
               : null,
-            timestampStart: startDateTime ? startDateTime.toMillis() : null,
-            timestampEnd: endDateTime ? endDateTime.toMillis() : null,
-            timeZoneStart: startDateTime ? startDateTime.zoneName : null,
-            timeZoneEnd: endDateTime ? endDateTime.zoneName : null,
+            timestampStart: startZonedDateTime
+              ? startZonedDateTime.epochMilliseconds
+              : null,
+            timestampEnd: endZonedDateTime
+              ? endZonedDateTime.epochMilliseconds
+              : null,
+            timeZoneStart: startZonedDateTime
+              ? startZonedDateTime.timeZoneId
+              : null,
+            timeZoneEnd: endZonedDateTime ? endZonedDateTime.timeZoneId : null,
+
             flags,
           },
           { tripId },
@@ -474,17 +474,20 @@ export function FlightForm({
   }, [
     activityFlags,
     activityId,
+    startDateTime,
     endDateTime,
+    startTimeZone,
+    endTimeZone,
     isIdea,
     locationFieldsState,
     mode,
     onFormSuccess,
     publishToast,
     setTripLocalState,
-    startDateTime,
-    tripEndDateTime,
-    tripId,
     tripStartDateTime,
+    tripEndDateTime,
+    tripTimeZone,
+    tripId,
   ]);
 
   const onFormInput = useCallback(() => {
@@ -631,7 +634,7 @@ export function FlightForm({
           name="startTime"
           mode={DateTimePickerMode.DateTime}
           min={tripStartDateTime?.subtract({ days: 1 })}
-          max={tripEndDateTime?.plus({ days: 1 })}
+          max={tripEndDateTime?.add({ days: 1 })}
           value={startDateTime}
           onChange={handleStartDateTimeChange}
           clearable={true}

--- a/src/Activity/FlightForm/FlightForm.tsx
+++ b/src/Activity/FlightForm/FlightForm.tsx
@@ -28,6 +28,10 @@ import {
 } from '../activityFlag';
 import { dbAddActivity, dbUpdateActivity } from '../db';
 import { airportGeocodingRequest } from './FlightFormGeocoding';
+import {
+  temporalToLuxonDate,
+  temporalToLuxonDateTime,
+} from '../../common/dateTime/luxonTemporalConverter';
 
 interface LocationCoordinateState {
   enabled: [boolean, boolean];
@@ -107,8 +111,8 @@ export function FlightForm({
   mode: ActivityFormModeType;
   activityId?: string;
   tripId?: string;
-  tripStartDateTime: DateTime | undefined;
-  tripEndDateTime: DateTime | undefined;
+  tripStartDateTime: Temporal.PlainDate | undefined;
+  tripEndDateTime: Temporal.PlainDate | undefined;
   tripTimeZone: string;
   tripRegion: string;
   activityTitle: string;
@@ -351,7 +355,11 @@ export function FlightForm({
       if (
         tripStartDateTime &&
         startDateTime &&
-        startDateTime < tripStartDateTime.minus({ days: 1 })
+        startDateTime <
+          temporalToLuxonDate(
+            tripStartDateTime.subtract({ days: 1 }),
+            tripTimeZone,
+          )
       ) {
         setErrorMessage(
           'Departure time cannot be earlier than 1 day before trip start',
@@ -361,7 +369,11 @@ export function FlightForm({
       if (
         tripEndDateTime &&
         endDateTime &&
-        endDateTime > tripEndDateTime.plus({ days: 1 })
+        endDateTime >
+          temporalToLuxonDate(
+            tripEndDateTime.add({ days: 1 }),
+            tripTimeZone,
+          )
       ) {
         setErrorMessage(
           'Arrival time cannot be later than 1 day after trip end',
@@ -618,7 +630,7 @@ export function FlightForm({
         <DateTimePicker
           name="startTime"
           mode={DateTimePickerMode.DateTime}
-          min={tripStartDateTime?.minus({ days: 1 })}
+          min={tripStartDateTime?.subtract({ days: 1 })}
           max={tripEndDateTime?.plus({ days: 1 })}
           value={startDateTime}
           onChange={handleStartDateTimeChange}
@@ -647,8 +659,8 @@ export function FlightForm({
         <DateTimePicker
           name="endTime"
           mode={DateTimePickerMode.DateTime}
-          min={tripStartDateTime?.minus({ days: 1 })}
-          max={tripEndDateTime?.plus({ days: 1 })}
+          min={tripStartDateTime?.subtract({ days: 1 })}
+          max={tripEndDateTime?.add({ days: 1 })}
           value={endDateTime}
           onChange={handleEndDateTimeChange}
           clearable={true}

--- a/src/Activity/FlightForm/FlightForm.tsx
+++ b/src/Activity/FlightForm/FlightForm.tsx
@@ -109,6 +109,7 @@ export function FlightForm({
   activityId?: string;
   tripId?: string;
   tripStartDateTime: Temporal.PlainDate | undefined;
+  /** Trip's final day */
   tripEndDateTime: Temporal.PlainDate | undefined;
   tripTimeZone: string;
   tripRegion: string;
@@ -359,7 +360,7 @@ export function FlightForm({
         endZonedDateTime &&
         Temporal.ZonedDateTime.compare(
           endZonedDateTime,
-          tripEndDateTime.add({ days: 1 }).toZonedDateTime(tripTimeZone),
+          tripEndDateTime.add({ days: 2 }).toZonedDateTime(tripTimeZone),
         ) > 0
       ) {
         setErrorMessage(

--- a/src/Activity/FlightForm/FlightFormGeocoding.ts
+++ b/src/Activity/FlightForm/FlightFormGeocoding.ts
@@ -27,7 +27,10 @@ export async function airportGeocodingRequest(
   let zoom: number | undefined;
 
   try {
+    // TODO: BUG? "HND" goes to "Henderson Executive Airport" (which has FAA code HND) instead of "Tokyo Haneda Airport" (which has IATA code HND)
+    console.log('Airport geocoding request:', query, geocodingOptions);
     const res = await geocoding.forward(query, geocodingOptions);
+    console.log('Airport geocoding response:', res);
     const feature = res?.features[0];
     if (feature) {
       [lng, lat] = feature.center ?? [];

--- a/src/Activity/FlightNewDialog.tsx
+++ b/src/Activity/FlightNewDialog.tsx
@@ -1,5 +1,4 @@
 import { Box, Dialog } from '@radix-ui/themes';
-import { DateTime } from 'luxon';
 import { useMemo } from 'react';
 import { CommonLargeDialogMaxWidth } from '../Dialog/ui';
 import { useBoundStore } from '../data/store';
@@ -21,36 +20,63 @@ export function FlightNewDialog({
   const localState = useTripLocalState(trip.id);
   const popDialog = useBoundStore((state) => state.popDialog);
 
-  const tripStartDateTime = DateTime.fromMillis(trip.timestampStart).setZone(
-    trip.timeZone,
-  );
-  const tripEndDateTime = DateTime.fromMillis(trip.timestampEnd)
-    .setZone(trip.timeZone)
-    .minus({ minute: 1 });
-
-  const [activityStartDateTime, activityEndDateTime] = useMemo(() => {
+  const tripStartDateTime = Temporal.Instant.fromEpochMilliseconds(
+    trip.timestampStart,
+  )
+    .toZonedDateTimeISO(trip.timeZone)
+    .toPlainDate();
+  const tripEndDateTime = Temporal.Instant.fromEpochMilliseconds(
+    trip.timestampEnd,
+  )
+    .toZonedDateTimeISO(trip.timeZone)
+    .toPlainDate()
+    .subtract({ days: 1 });
+  const [
+    activityStartDateTime,
+    activityEndDateTime,
+    activityStartTimeZone,
+    activityEndTimeZone,
+  ] = useMemo(() => {
     if (prefillData) {
+      // Convert timeStart (HHMM format) to DateTime
       const hours = parseInt(prefillData.timeStart.substring(0, 2), 10);
       const minutes = parseInt(prefillData.timeStart.substring(2, 4), 10);
-      const tripStart = DateTime.fromMillis(trip.timestampStart).setZone(
-        trip.timeZone,
-      );
+
+      // Calculate the start of the selected day
+      const tripStart = Temporal.Instant.fromEpochMilliseconds(
+        trip.timestampStart,
+      ).toZonedDateTimeISO(trip.timeZone);
       const activityDay = tripStart
-        .plus({ days: prefillData.dayOfTrip - 1 })
-        .startOf('day');
-      const activityStartTime = activityDay.set({
+        .add({ days: prefillData.dayOfTrip - 1 })
+        .startOfDay();
+
+      // Set the specific time on that day
+      const activityStartZonedTime = activityDay.with({
         hour: hours,
         minute: minutes,
       });
-      const activityEndTime = activityStartTime.plus({ hours: 2 });
-      return [activityStartTime, activityEndTime];
+      const activityEndZonedTime = activityStartZonedTime.add({ hours: 2 });
+
+      return [
+        activityStartZonedTime.toPlainDateTime(),
+        activityEndZonedTime.toPlainDateTime(),
+        activityStartZonedTime.timeZoneId,
+        activityEndZonedTime.timeZoneId,
+      ];
     }
 
-    const activityStartTime = DateTime.fromMillis(
+    // Default behavior when no prefillData
+    const activityStartZonedTime = Temporal.Instant.fromEpochMilliseconds(
       localState?.activityTimestampStart ?? trip.timestampStart,
-    ).setZone(trip.timeZone);
-    const activityEndTime = activityStartTime.plus({ hours: 2 });
-    return [activityStartTime, activityEndTime];
+    ).toZonedDateTimeISO(trip.timeZone);
+    const activityEndZonedTime = activityStartZonedTime.add({ hours: 2 });
+
+    return [
+      activityStartZonedTime.toPlainDateTime(),
+      activityEndZonedTime.toPlainDateTime(),
+      activityStartZonedTime.timeZoneId,
+      activityEndZonedTime.timeZoneId,
+    ];
   }, [trip, prefillData, localState?.activityTimestampStart]);
 
   return (
@@ -72,6 +98,8 @@ export function FlightNewDialog({
           activityIcon="✈️"
           activityStartDateTime={activityStartDateTime}
           activityEndDateTime={activityEndDateTime}
+          activityStartTimeZone={activityStartTimeZone}
+          activityEndTimeZone={activityEndTimeZone}
           activityLocation=""
           activityDescription=""
           activityLocationLat={undefined}

--- a/src/Activity/db.ts
+++ b/src/Activity/db.ts
@@ -29,9 +29,9 @@ export type DbActivity = {
   locationDestinationZoom: undefined | null | number;
 
   description: string;
-  /** ms */
+  /** ms; possible to be before trip.timestampStart + 1d */
   timestampStart: number | null | undefined;
-  /** ms */
+  /** ms; possible to be after trip.timestampEnd + 1d */
   timestampEnd: number | null | undefined;
 
   /** default: trip.timeZone */

--- a/src/Activity/db.ts
+++ b/src/Activity/db.ts
@@ -29,9 +29,9 @@ export type DbActivity = {
   locationDestinationZoom: undefined | null | number;
 
   description: string;
-  /** ms; possible to be before trip.timestampStart + 1d */
+  /** ms; possible to be as early as trip.timestampStart - 1d */
   timestampStart: number | null | undefined;
-  /** ms; possible to be after trip.timestampEnd + 1d */
+  /** ms; possible to be up to but not after trip.timestampEnd + 1d */
   timestampEnd: number | null | undefined;
 
   /** default: trip.timeZone */

--- a/src/Expense/ExpenseCard.tsx
+++ b/src/Expense/ExpenseCard.tsx
@@ -16,7 +16,6 @@ import {
   Text,
   Tooltip,
 } from '@radix-ui/themes';
-import { DateTime } from 'luxon';
 import { useCallback, useMemo, useState } from 'react';
 import { CommentGroupWithForm } from '../Comment/CommentGroupWithForm';
 import { COMMENT_GROUP_OBJECT_TYPE } from '../Comment/db';
@@ -150,9 +149,9 @@ function ExpenseCardView({
         <Text size="1" color="gray" className={s.date}>
           {trip
             ? formatTimestampToReadableDate(
-                DateTime.fromMillis(expense.timestampIncurred, {
-                  zone: trip.timeZone,
-                }),
+                Temporal.Instant.fromEpochMilliseconds(
+                  expense.timestampIncurred,
+                ).toZonedDateTimeISO(trip.timeZone),
               )
             : ''}
         </Text>

--- a/src/Expense/ExpenseHeaderCard.tsx
+++ b/src/Expense/ExpenseHeaderCard.tsx
@@ -1,5 +1,4 @@
 import { Badge, Box, Card, Heading, Text } from '@radix-ui/themes';
-import { DateTime } from 'luxon';
 import { useMemo } from 'react';
 import { getTripStatus } from '../Trip/getTripStatus';
 import { useCurrentTrip, useTripExpenses } from '../Trip/store/hooks';
@@ -24,12 +23,12 @@ export function ExpenseHeaderCard() {
   const dailyExpenseSummary = useMemo(() => {
     if (!trip || !expenses || expenses.length === 0) return null;
 
-    const tripStart = DateTime.fromMillis(trip.timestampStart).setZone(
-      trip.timeZone,
-    );
-    const tripEnd = DateTime.fromMillis(trip.timestampEnd).setZone(
-      trip.timeZone,
-    );
+    const tripStart = Temporal.Instant.fromEpochMilliseconds(
+      trip.timestampStart,
+    ).toZonedDateTimeISO(trip.timeZone);
+    const tripEnd = Temporal.Instant.fromEpochMilliseconds(
+      trip.timestampEnd,
+    ).toZonedDateTimeISO(trip.timeZone);
     const tripStatus = getTripStatus(tripStart, tripEnd);
 
     // Future trip - don't show this item
@@ -37,26 +36,27 @@ export function ExpenseHeaderCard() {
       return null;
     }
 
-    let targetDate: DateTime;
+    let targetDate: Temporal.ZonedDateTime;
     let label: string;
 
     // Current trip - show today's total
     if (tripStatus.status === 'current') {
-      targetDate = DateTime.now().setZone(trip.timeZone).startOf('day');
+      targetDate = Temporal.Now.zonedDateTimeISO(trip.timeZone).startOfDay();
       label = 'Today';
     }
     // Past trip - show final day's expense
     else {
       // Final day is one day before timestampEnd
-      targetDate = tripEnd.minus({ days: 1 }).startOf('day');
+      targetDate = tripEnd.subtract({ days: 1 }).startOfDay();
       label = 'Final Day';
     }
 
     const targetExpenses = expenses.filter((expense) => {
-      const expenseDate = DateTime.fromMillis(
+      const expenseDate = Temporal.Instant.fromEpochMilliseconds(
         expense.timestampIncurred,
-      ).setZone(trip.timeZone);
-      return expenseDate.hasSame(targetDate, 'day');
+      ).toZonedDateTimeISO(trip.timeZone);
+      // Check if expenseDate is the same day as targetDate
+      return Temporal.ZonedDateTime.compare(expenseDate.startOfDay(), targetDate) === 0;
     });
 
     let total = 0;

--- a/src/Expense/ExpenseHeaderCard.tsx
+++ b/src/Expense/ExpenseHeaderCard.tsx
@@ -56,7 +56,10 @@ export function ExpenseHeaderCard() {
         expense.timestampIncurred,
       ).toZonedDateTimeISO(trip.timeZone);
       // Check if expenseDate is the same day as targetDate
-      return Temporal.ZonedDateTime.compare(expenseDate.startOfDay(), targetDate) === 0;
+      return (
+        Temporal.ZonedDateTime.compare(expenseDate.startOfDay(), targetDate) ===
+        0
+      );
     });
 
     let total = 0;

--- a/src/Expense/ExpenseInlineCardForm.tsx
+++ b/src/Expense/ExpenseInlineCardForm.tsx
@@ -1,6 +1,5 @@
 import { QuestionMarkCircledIcon } from '@radix-ui/react-icons';
 import { Button, Select, Text, TextField, Tooltip } from '@radix-ui/themes';
-import { DateTime } from 'luxon';
 import type * as React from 'react';
 import { useCallback, useId, useMemo, useRef, useState } from 'react';
 import { DateTimePicker } from '../common/DatePicker2/DateTimePicker';
@@ -29,15 +28,17 @@ export function ExpenseInlineCardForm({
   );
   const setTripLocalState = useBoundStore((state) => state.setTripLocalState);
 
-  const dateTimeIncurred: DateTime<boolean> = useMemo(
+  const dateTimeIncurred: Temporal.PlainDate = useMemo(
     () =>
-      DateTime.fromMillis(
+      Temporal.Instant.fromEpochMilliseconds(
         expenseMode === ExpenseMode.Edit && expense
           ? expense.timestampIncurred
           : tripLocalState?.expenseTimestampIncurred != null
             ? tripLocalState?.expenseTimestampIncurred
             : trip.timestampStart,
-      ).setZone(trip.timeZone),
+      )
+        .toZonedDateTimeISO(trip.timeZone)
+        .toPlainDate(),
     [
       trip.timestampStart,
       trip.timeZone,
@@ -163,8 +164,10 @@ export function ExpenseInlineCardForm({
           amount: amountFloat,
           currencyConversionFactor: currencyConversionFactorFloat,
           amountInOriginCurrency: amountInOriginCurrencyFloat,
-          timestampIncurred: dateTimeIncurred.toMillis(),
-          timeZoneIncurred: dateTimeIncurred.zoneName ?? timeZoneIncurred,
+          timestampIncurred:
+            dateTimeIncurred.toZonedDateTime(timeZoneIncurred)
+              .epochMilliseconds,
+          timeZoneIncurred: timeZoneIncurred,
         })
           .then(() => {
             publishToast({
@@ -175,7 +178,9 @@ export function ExpenseInlineCardForm({
             setTripLocalState(trip.id, {
               expenseCurrency: currency,
               expenseCurrencyConversionFactor: currencyConversionFactorFloat,
-              expenseTimestampIncurred: dateTimeIncurred.toMillis(),
+              expenseTimestampIncurred:
+                dateTimeIncurred.toZonedDateTime(timeZoneIncurred)
+                  .epochMilliseconds,
             });
 
             setExpenseMode(ExpenseMode.View);
@@ -203,8 +208,10 @@ export function ExpenseInlineCardForm({
             amount: amountFloat,
             currencyConversionFactor: currencyConversionFactorFloat,
             amountInOriginCurrency: amountInOriginCurrencyFloat,
-            timestampIncurred: dateTimeIncurred.toMillis(),
-            timeZoneIncurred: dateTimeIncurred.zoneName ?? timeZoneIncurred,
+            timestampIncurred:
+              dateTimeIncurred.toZonedDateTime(timeZoneIncurred)
+                .epochMilliseconds,
+            timeZoneIncurred: timeZoneIncurred,
           },
           { tripId: trip.id },
         )
@@ -212,7 +219,9 @@ export function ExpenseInlineCardForm({
             setTripLocalState(trip.id, {
               expenseCurrency: currency,
               expenseCurrencyConversionFactor: currencyConversionFactorFloat,
-              expenseTimestampIncurred: dateTimeIncurred.toMillis(),
+              expenseTimestampIncurred:
+                dateTimeIncurred.toZonedDateTime(timeZoneIncurred)
+                  .epochMilliseconds,
             });
             publishToast({
               root: {},
@@ -253,11 +262,14 @@ export function ExpenseInlineCardForm({
   const refTitle = useRef<HTMLInputElement>(null);
 
   const handleTimestampIncurredChange = useCallback(
-    (value: DateTime | undefined) => {
+    (value: Temporal.PlainDate | Temporal.PlainDateTime | undefined) => {
       if (value) {
         setFormState((prev) => ({
           ...prev,
-          dateTimeIncurred: value,
+          dateTimeIncurred:
+            value instanceof Temporal.PlainDateTime
+              ? value.toPlainDate()
+              : value,
         }));
       }
     },

--- a/src/Expense/time.ts
+++ b/src/Expense/time.ts
@@ -1,7 +1,8 @@
- 
 import { toFormat } from '../common/dateTime/temporalFormatter';
 
-export function formatTimestampToReadableDate(dateTime: Temporal.ZonedDateTime): string {
+export function formatTimestampToReadableDate(
+  dateTime: Temporal.ZonedDateTime,
+): string {
   // TODO: check if without time zone information this will be formatted correctly?
   return toFormat('d LLLL yyyy', dateTime.toPlainDateTime());
 }

--- a/src/Expense/time.ts
+++ b/src/Expense/time.ts
@@ -1,5 +1,7 @@
-import type { DateTime } from 'luxon';
+ 
+import { toFormat } from '../common/dateTime/temporalFormatter';
 
-export function formatTimestampToReadableDate(dateTime: DateTime) {
-  return dateTime.toFormat('d LLLL yyyy');
+export function formatTimestampToReadableDate(dateTime: Temporal.ZonedDateTime): string {
+  // TODO: check if without time zone information this will be formatted correctly?
+  return toFormat('d LLLL yyyy', dateTime.toPlainDateTime());
 }

--- a/src/Macroplan/MacroplanDialog/MacroplanDialogContentEdit.tsx
+++ b/src/Macroplan/MacroplanDialog/MacroplanDialogContentEdit.tsx
@@ -1,5 +1,4 @@
 import { Box, Dialog, Spinner } from '@radix-ui/themes';
-import { DateTime } from 'luxon';
 import { useCallback } from 'react';
 import type { DialogContentProps } from '../../Dialog/DialogRoute';
 import { useTrip } from '../../Trip/store/hooks';
@@ -19,27 +18,31 @@ export function MacroplanDialogContentEdit({
 
   const tripStartDateTime =
     macroplan && trip
-      ? DateTime.fromMillis(trip.timestampStart).setZone(trip.timeZone)
+      ? Temporal.Instant.fromEpochMilliseconds(trip.timestampStart)
+          .toZonedDateTimeISO(trip.timeZone)
+          .toPlainDate()
       : undefined;
   const tripEndDateTime =
     macroplan && trip
-      ? DateTime.fromMillis(trip.timestampEnd)
-          .setZone(trip.timeZone)
-          .minus({ minute: 1 })
+      ? Temporal.Instant.fromEpochMilliseconds(trip.timestampEnd)
+          .toZonedDateTimeISO(trip.timeZone)
+          .toPlainDate()
+          .subtract({ days: 1 })
       : undefined;
 
-  const macroplanDateStartDateTime =
-    macroplan && trip
-      ? DateTime.fromMillis(macroplan.timestampStart).setZone(
-          macroplan.timeZoneStart ?? trip.timeZone,
-        )
+  const macroplanStartDate =
+    macroplan && trip && macroplan.timestampStart != null
+      ? Temporal.Instant.fromEpochMilliseconds(macroplan.timestampStart)
+          .toZonedDateTimeISO(macroplan.timeZoneStart ?? trip.timeZone)
+          .toPlainDate()
       : undefined;
-  const macroplanDateEndDateTime =
-    macroplan && trip
-      ? DateTime.fromMillis(macroplan.timestampEnd)
-          .setZone(macroplan.timeZoneEnd ?? trip.timeZone)
-          .minus({ minute: 1 })
+  const macroplanEndDate =
+    macroplan && trip && macroplan.timestampEnd != null
+      ? Temporal.Instant.fromEpochMilliseconds(macroplan.timestampEnd)
+          .toZonedDateTimeISO(macroplan.timeZoneEnd ?? trip.timeZone)
+          .toPlainDate()
       : undefined;
+
   const backToViewMode = useCallback(() => {
     setMode(MacroplanDialogMode.View);
   }, [setMode]);
@@ -65,11 +68,13 @@ export function MacroplanDialogContentEdit({
           tripId={macroplan.tripId}
           macroplanId={macroplan.id}
           tripTimeZone={trip.timeZone}
-          tripStartDateTime={tripStartDateTime}
-          tripEndDateTime={tripEndDateTime}
+          tripStartDate={tripStartDateTime}
+          tripEndDate={tripEndDateTime}
           macroplanName={macroplan.name}
-          macroplanDateStartDateTime={macroplanDateStartDateTime}
-          macroplanDateEndDateTime={macroplanDateEndDateTime}
+          macroplanStartDate={macroplanStartDate}
+          macroplanEndDate={macroplanEndDate}
+          macroplanStartTimeZone={macroplan.timeZoneStart || trip.timeZone}
+          macroplanEndTimeZone={macroplan.timeZoneEnd || trip.timeZone}
           macroplanNotes={macroplan.notes}
           onFormCancel={backToViewMode}
           onFormSuccess={backToViewMode}

--- a/src/Macroplan/MacroplanDialog/MacroplanDialogContentEdit.tsx
+++ b/src/Macroplan/MacroplanDialog/MacroplanDialogContentEdit.tsx
@@ -41,6 +41,7 @@ export function MacroplanDialogContentEdit({
       ? Temporal.Instant.fromEpochMilliseconds(macroplan.timestampEnd)
           .toZonedDateTimeISO(macroplan.timeZoneEnd ?? trip.timeZone)
           .toPlainDate()
+          .subtract({ days: 1 })
       : undefined;
 
   const backToViewMode = useCallback(() => {

--- a/src/Macroplan/MacroplanForm.tsx
+++ b/src/Macroplan/MacroplanForm.tsx
@@ -1,5 +1,4 @@
 import { Button, Flex, Text, TextArea, TextField } from '@radix-ui/themes';
-import type { DateTime } from 'luxon';
 import type { SubmitEvent } from 'react';
 import { useCallback, useId, useState } from 'react';
 import { DateTimePicker } from '../common/DatePicker2/DateTimePicker';
@@ -19,12 +18,14 @@ export function MacroplanForm({
   tripId,
 
   tripTimeZone,
-  tripStartDateTime,
-  tripEndDateTime,
+  tripStartDate,
+  tripEndDate,
 
   macroplanName,
-  macroplanDateStartDateTime,
-  macroplanDateEndDateTime,
+  macroplanStartDate,
+  macroplanEndDate,
+  macroplanStartTimeZone,
+  macroplanEndTimeZone,
   macroplanNotes,
 
   onFormSuccess,
@@ -36,12 +37,14 @@ export function MacroplanForm({
   macroplanId?: string;
 
   tripTimeZone: string;
-  tripStartDateTime: DateTime | undefined;
-  tripEndDateTime: DateTime | undefined;
+  tripStartDate: Temporal.PlainDate | undefined;
+  tripEndDate: Temporal.PlainDate | undefined;
 
   macroplanName: string;
-  macroplanDateStartDateTime: DateTime | undefined;
-  macroplanDateEndDateTime: DateTime | undefined;
+  macroplanStartDate: Temporal.PlainDate | undefined;
+  macroplanEndDate: Temporal.PlainDate | undefined;
+  macroplanStartTimeZone: string | undefined;
+  macroplanEndTimeZone: string | undefined;
   macroplanNotes: string;
 
   onFormSuccess: () => void;
@@ -53,43 +56,50 @@ export function MacroplanForm({
   const publishToast = useBoundStore((state) => state.publishToast);
 
   const [errorMessage, setErrorMessage] = useState('');
-  const [dateStart, setDateStart] = useState<DateTime | undefined>(
-    macroplanDateStartDateTime,
+  const [dateStart, setDateStart] = useState<Temporal.PlainDate | undefined>(
+    macroplanStartDate,
   );
-  const [dateEnd, setDateEnd] = useState<DateTime | undefined>(
-    macroplanDateEndDateTime,
+  const [dateEnd, setDateEnd] = useState<Temporal.PlainDate | undefined>(
+    macroplanEndDate,
+  );
+  const [timeZoneStart, setTimeZoneStart] = useState<string>(
+    macroplanStartTimeZone ?? tripTimeZone,
+  );
+  const [timeZoneEnd, setTimeZoneEnd] = useState<string>(
+    macroplanEndTimeZone ?? tripTimeZone,
   );
 
   const handleStartDateChange = useCallback(
-    (dateTime: DateTime | undefined) => {
-      setDateStart(dateTime);
+    (dateTime: Temporal.PlainDate | Temporal.PlainDateTime | undefined) => {
+      if (dateTime instanceof Temporal.PlainDateTime) {
+        setDateStart(dateTime.toPlainDate());
+      } else {
+        setDateStart(dateTime);
+      }
       setErrorMessage(''); // Clear any date-related errors
     },
     [],
   );
 
-  const handleEndDateChange = useCallback((dateTime: DateTime | undefined) => {
-    setDateEnd(dateTime);
-    setErrorMessage(''); // Clear any date-related errors
+  const handleEndDateChange = useCallback(
+    (dateTime: Temporal.PlainDate | Temporal.PlainDateTime | undefined) => {
+      if (dateTime instanceof Temporal.PlainDateTime) {
+        setDateEnd(dateTime.toPlainDate());
+      } else {
+        setDateEnd(dateTime);
+      }
+      setErrorMessage(''); // Clear any date-related errors
+    },
+    [],
+  );
+
+  const handleTimeZoneStartChange = useCallback((newTimeZone: string) => {
+    setTimeZoneStart(newTimeZone);
   }, []);
 
-  const handleTimeZoneStartChange = useCallback(
-    (newTimeZone: string) => {
-      if (dateStart) {
-        setDateStart(dateStart.setZone(newTimeZone, { keepLocalTime: true }));
-      }
-    },
-    [dateStart],
-  );
-
-  const handleTimeZoneEndChange = useCallback(
-    (newTimeZone: string) => {
-      if (dateEnd) {
-        setDateEnd(dateEnd.setZone(newTimeZone, { keepLocalTime: true }));
-      }
-    },
-    [dateEnd],
-  );
+  const handleTimeZoneEndChange = useCallback((newTimeZone: string) => {
+    setTimeZoneEnd(newTimeZone);
+  }, []);
 
   const handleSubmit = useCallback(() => {
     return async (elForm: HTMLFormElement) => {
@@ -104,7 +114,7 @@ export function MacroplanForm({
       const name = (formData.get('name') as string | null) ?? '';
       const notes = (formData.get('notes') as string | null) ?? '';
       const dateStartDateTime = dateStart;
-      const dateEndDateTime = dateEnd?.plus({ day: 1 });
+      const dateEndDateTime = dateEnd?.add({ days: 1 });
       console.log('MacroplanForm', {
         mode,
         macroplanId,
@@ -117,21 +127,25 @@ export function MacroplanForm({
       if (!name || !dateStartDateTime || !dateEndDateTime) {
         return;
       }
-      if (dateEndDateTime.diff(dateStartDateTime).as('minute') < 0) {
+      if (Temporal.PlainDate.compare(dateStartDateTime, dateEndDateTime) > 0) {
         setErrorMessage('End date must not be before start date');
         return;
       }
       // start date cannot be earlier than trip start date
-      if (tripStartDateTime && dateStartDateTime < tripStartDateTime) {
+      if (
+        tripStartDate &&
+        Temporal.PlainDate.compare(dateStartDateTime, tripStartDate) < 0
+      ) {
         setErrorMessage('Start date cannot be earlier than trip start date');
         return;
       }
       // end date cannot be later than trip end date
       // in db, the convention for 'end date' date-level entities are that they stored as start of next day
+      // TODO: validate this assumption
       // however, tripEndDateTime prop has been adjusted to be the last minute of the trip
       if (
-        tripEndDateTime &&
-        dateEndDateTime > tripEndDateTime.plus({ minute: 1 })
+        tripEndDate &&
+        Temporal.PlainDate.compare(dateEndDateTime, tripEndDate) > 0
       ) {
         setErrorMessage('End date cannot be later than trip end date');
         return;
@@ -140,10 +154,12 @@ export function MacroplanForm({
         await dbUpdateMacroplan({
           id: macroplanId,
           name,
-          timestampStart: dateStartDateTime.toMillis(),
-          timestampEnd: dateEndDateTime.toMillis(),
-          timeZoneStart: dateStartDateTime.zoneName,
-          timeZoneEnd: dateEndDateTime.zoneName,
+          timestampStart:
+            dateStartDateTime.toZonedDateTime(timeZoneStart).epochMilliseconds,
+          timestampEnd:
+            dateEndDateTime.toZonedDateTime(timeZoneStart).epochMilliseconds,
+          timeZoneStart: timeZoneStart,
+          timeZoneEnd: timeZoneEnd,
           notes,
         });
         publishToast({
@@ -155,10 +171,12 @@ export function MacroplanForm({
         const { id, result } = await dbAddMacroplan(
           {
             name,
-            timestampStart: dateStartDateTime.toMillis(),
-            timestampEnd: dateEndDateTime.toMillis(),
-            timeZoneStart: dateStartDateTime.zoneName,
-            timeZoneEnd: dateEndDateTime.zoneName,
+          timestampStart:
+            dateStartDateTime.toZonedDateTime(timeZoneStart).epochMilliseconds,
+          timestampEnd:
+            dateEndDateTime.toZonedDateTime(timeZoneStart).epochMilliseconds,
+          timeZoneStart: timeZoneStart,
+          timeZoneEnd: timeZoneEnd,
             notes,
           },
           {
@@ -184,8 +202,10 @@ export function MacroplanForm({
     tripId,
     dateStart,
     dateEnd,
-    tripStartDateTime,
-    tripEndDateTime,
+    tripStartDate,
+    tripEndDate,
+    timeZoneStart,
+    timeZoneEnd,
   ]);
 
   const onFormInput = useCallback(() => {
@@ -227,14 +247,14 @@ export function MacroplanForm({
         <TimeZoneSelect
           id="timeZoneStart"
           name="timeZoneStart"
-          value={dateStart?.zoneName ?? tripTimeZone}
+          value={timeZoneStart}
           handleChange={handleTimeZoneStartChange}
           isFormLoading={false}
         />
         <Text as="label">
           Start date{' '}
           <Text weight="light" size="1">
-            (required; in {dateStart?.zoneName ?? tripTimeZone} time zone)
+            (required; in {timeZoneStart} time zone)
           </Text>
         </Text>
         <DateTimePicker
@@ -246,8 +266,8 @@ export function MacroplanForm({
           aria-label="Day plan start date"
           placeholder="Select start date"
           // Buffer one day before and after trip start/end date to allow some flexibility
-          min={tripStartDateTime?.minus({ days: 1 })}
-          max={tripEndDateTime?.plus({ days: 1 })}
+          min={tripStartDate?.subtract({ days: 1 })}
+          max={tripEndDate?.add({ days: 1 })}
         />
 
         <Text as="label">
@@ -259,14 +279,14 @@ export function MacroplanForm({
         <TimeZoneSelect
           id="timeZoneEnd"
           name="timeZoneEnd"
-          value={dateEnd?.zoneName ?? tripTimeZone}
+          value={timeZoneEnd}
           handleChange={handleTimeZoneEndChange}
           isFormLoading={false}
         />
         <Text as="label">
           End date{' '}
           <Text weight="light" size="1">
-            (required; in {dateEnd?.zoneName ?? tripTimeZone} time zone)
+            (required; in {timeZoneEnd} time zone)
           </Text>
         </Text>
         <DateTimePicker
@@ -278,8 +298,8 @@ export function MacroplanForm({
           aria-label="Day plan end date"
           placeholder="Select end date"
           // Buffer one day before and after trip start/end date to allow some flexibility
-          min={tripStartDateTime?.minus({ days: 1 })}
-          max={tripEndDateTime?.plus({ days: 1 })}
+          min={tripStartDate?.subtract({ days: 1 })}
+          max={tripEndDate?.add({ days: 1 })}
         />
         <Text as="label" htmlFor={idNotes}>
           Notes

--- a/src/Macroplan/MacroplanForm.tsx
+++ b/src/Macroplan/MacroplanForm.tsx
@@ -38,10 +38,12 @@ export function MacroplanForm({
 
   tripTimeZone: string;
   tripStartDate: Temporal.PlainDate | undefined;
+  /** final day of the trip */
   tripEndDate: Temporal.PlainDate | undefined;
 
   macroplanName: string;
   macroplanStartDate: Temporal.PlainDate | undefined;
+  /** final day of the macroplan */
   macroplanEndDate: Temporal.PlainDate | undefined;
   macroplanStartTimeZone: string | undefined;
   macroplanEndTimeZone: string | undefined;
@@ -59,9 +61,11 @@ export function MacroplanForm({
   const [dateStart, setDateStart] = useState<Temporal.PlainDate | undefined>(
     macroplanStartDate,
   );
-  const [dateEnd, setDateEnd] = useState<Temporal.PlainDate | undefined>(
-    macroplanEndDate,
-  );
+  const [
+    /** Final date of the macroplan */
+    dateEnd,
+    setDateEnd,
+  ] = useState<Temporal.PlainDate | undefined>(macroplanEndDate);
   const [timeZoneStart, setTimeZoneStart] = useState<string>(
     macroplanStartTimeZone ?? tripTimeZone,
   );
@@ -113,40 +117,35 @@ export function MacroplanForm({
       const formData = new FormData(elForm);
       const name = (formData.get('name') as string | null) ?? '';
       const notes = (formData.get('notes') as string | null) ?? '';
-      const dateStartDateTime = dateStart;
-      const dateEndDateTime = dateEnd?.add({ days: 1 });
+      const dateStartForDb = dateStart;
+      /** in db, the convention is to store 'date end' as the day _after_ the selected end date */
+      const dateEndForDb = dateEnd?.add({ days: 1 });
       console.log('MacroplanForm', {
         mode,
         macroplanId,
         tripId,
         name,
         notes,
-        dateStartDateTime,
-        dateEndDateTime,
+        dateStartDateTime: dateStartForDb,
+        dateEndDateTime: dateEndForDb,
       });
-      if (!name || !dateStartDateTime || !dateEndDateTime) {
+      if (!name || !dateStart || !dateEnd || !dateStartForDb || !dateEndForDb) {
         return;
       }
-      if (Temporal.PlainDate.compare(dateStartDateTime, dateEndDateTime) > 0) {
+      if (Temporal.PlainDate.compare(dateStartForDb, dateEnd) > 0) {
         setErrorMessage('End date must not be before start date');
         return;
       }
       // start date cannot be earlier than trip start date
       if (
         tripStartDate &&
-        Temporal.PlainDate.compare(dateStartDateTime, tripStartDate) < 0
+        Temporal.PlainDate.compare(dateStartForDb, tripStartDate) < 0
       ) {
         setErrorMessage('Start date cannot be earlier than trip start date');
         return;
       }
       // end date cannot be later than trip end date
-      // in db, the convention for 'end date' date-level entities are that they stored as start of next day
-      // TODO: validate this assumption
-      // however, tripEndDateTime prop has been adjusted to be the last minute of the trip
-      if (
-        tripEndDate &&
-        Temporal.PlainDate.compare(dateEndDateTime, tripEndDate) > 0
-      ) {
+      if (tripEndDate && Temporal.PlainDate.compare(dateEnd, tripEndDate) > 0) {
         setErrorMessage('End date cannot be later than trip end date');
         return;
       }
@@ -155,9 +154,9 @@ export function MacroplanForm({
           id: macroplanId,
           name,
           timestampStart:
-            dateStartDateTime.toZonedDateTime(timeZoneStart).epochMilliseconds,
+            dateStartForDb.toZonedDateTime(timeZoneStart).epochMilliseconds,
           timestampEnd:
-            dateEndDateTime.toZonedDateTime(timeZoneStart).epochMilliseconds,
+            dateEndForDb.toZonedDateTime(timeZoneEnd).epochMilliseconds,
           timeZoneStart: timeZoneStart,
           timeZoneEnd: timeZoneEnd,
           notes,
@@ -172,10 +171,9 @@ export function MacroplanForm({
           {
             name,
             timestampStart:
-              dateStartDateTime.toZonedDateTime(timeZoneStart)
-                .epochMilliseconds,
+              dateStartForDb.toZonedDateTime(timeZoneStart).epochMilliseconds,
             timestampEnd:
-              dateEndDateTime.toZonedDateTime(timeZoneStart).epochMilliseconds,
+              dateEndForDb.toZonedDateTime(timeZoneEnd).epochMilliseconds,
             timeZoneStart: timeZoneStart,
             timeZoneEnd: timeZoneEnd,
             notes,

--- a/src/Macroplan/MacroplanForm.tsx
+++ b/src/Macroplan/MacroplanForm.tsx
@@ -171,12 +171,13 @@ export function MacroplanForm({
         const { id, result } = await dbAddMacroplan(
           {
             name,
-          timestampStart:
-            dateStartDateTime.toZonedDateTime(timeZoneStart).epochMilliseconds,
-          timestampEnd:
-            dateEndDateTime.toZonedDateTime(timeZoneStart).epochMilliseconds,
-          timeZoneStart: timeZoneStart,
-          timeZoneEnd: timeZoneEnd,
+            timestampStart:
+              dateStartDateTime.toZonedDateTime(timeZoneStart)
+                .epochMilliseconds,
+            timestampEnd:
+              dateEndDateTime.toZonedDateTime(timeZoneStart).epochMilliseconds,
+            timeZoneStart: timeZoneStart,
+            timeZoneEnd: timeZoneEnd,
             notes,
           },
           {

--- a/src/Macroplan/MacroplanForm.tsx
+++ b/src/Macroplan/MacroplanForm.tsx
@@ -264,9 +264,8 @@ export function MacroplanForm({
           required
           aria-label="Day plan start date"
           placeholder="Select start date"
-          // Buffer one day before and after trip start/end date to allow some flexibility
-          min={tripStartDate?.subtract({ days: 1 })}
-          max={tripEndDate?.add({ days: 1 })}
+          min={tripStartDate}
+          max={tripEndDate}
         />
 
         <Text as="label">
@@ -296,9 +295,8 @@ export function MacroplanForm({
           required
           aria-label="Day plan end date"
           placeholder="Select end date"
-          // Buffer one day before and after trip start/end date to allow some flexibility
-          min={tripStartDate?.subtract({ days: 1 })}
-          max={tripEndDate?.add({ days: 1 })}
+          min={tripStartDate}
+          max={tripEndDate}
         />
         <Text as="label" htmlFor={idNotes}>
           Notes

--- a/src/Macroplan/MacroplanNewDialog.tsx
+++ b/src/Macroplan/MacroplanNewDialog.tsx
@@ -1,5 +1,4 @@
 import { Dialog, Text } from '@radix-ui/themes';
-import { DateTime } from 'luxon';
 import { useMemo } from 'react';
 import { CommonLargeDialogMaxWidth } from '../Dialog/ui';
 import { useBoundStore } from '../data/store';
@@ -17,44 +16,60 @@ export function MacroplanNewDialog({
   };
 }) {
   const popDialog = useBoundStore((state) => state.popDialog);
-  const tripStartDateTime = DateTime.fromMillis(trip.timestampStart).setZone(
-    trip.timeZone,
-  );
-  const tripEndDateTime = DateTime.fromMillis(trip.timestampEnd)
-    .setZone(trip.timeZone)
-    .minus({ minute: 1 });
 
-  const [macroplanCheckInDateTime, macroplanCheckOutDateTime] = useMemo(() => {
+  const tripStartDateTime = Temporal.Instant.fromEpochMilliseconds(
+    trip.timestampStart,
+  )
+    .toZonedDateTimeISO(trip.timeZone)
+    .toPlainDate();
+  const tripEndDateTime = Temporal.Instant.fromEpochMilliseconds(
+    trip.timestampEnd,
+  )
+    .toZonedDateTimeISO(trip.timeZone)
+    .toPlainDate()
+    .subtract({ days: 1 });
+
+  const [
+    macroplanStartDate,
+    macroplanEndDate,
+    macroplanStartTimeZone,
+    macroplanEndTimeZone,
+  ] = useMemo(() => {
     if (prefillData) {
       // Calculate the start of the selected day
-      const tripStart = DateTime.fromMillis(trip.timestampStart).setZone(
-        trip.timeZone,
-      );
+      const tripStart = Temporal.Instant.fromEpochMilliseconds(
+        trip.timestampStart,
+      ).toZonedDateTimeISO(trip.timeZone);
       const selectedDay = tripStart
-        .plus({ days: prefillData.dayOfTrip - 1 })
-        .startOf('day');
+        .add({ days: prefillData.dayOfTrip - 1 })
+        .startOfDay();
 
       // Set start date to the selected day
       const startDate = selectedDay;
       // Set end date to the same day (single day plan by default)
       const endDate = selectedDay;
 
-      return [startDate, endDate];
+      return [
+        startDate.toPlainDate(),
+        endDate.toPlainDate(),
+        trip.timeZone,
+        trip.timeZone,
+      ];
     }
 
     // Default behavior when no prefillData
     return [
-      DateTime.fromMillis(trip.timestampStart)
-        .setZone(trip.timeZone)
-        // Usually check-in is 3pm of the first day
-        .plus({ hour: 15 }),
-      DateTime.fromMillis(trip.timestampEnd)
-        .setZone(trip.timeZone)
-        .minus({
-          day: 1,
+      Temporal.Instant.fromEpochMilliseconds(trip.timestampStart)
+        .toZonedDateTimeISO(trip.timeZone)
+        .toPlainDate(),
+      Temporal.Instant.fromEpochMilliseconds(trip.timestampEnd)
+        .toZonedDateTimeISO(trip.timeZone)
+        .subtract({
+          days: 1,
         })
-        // Usually check-out is 11am of the last day
-        .plus({ hour: 11 }),
+        .toPlainDate(),
+      trip.timeZone,
+      trip.timeZone,
     ];
   }, [trip, prefillData]);
 
@@ -84,11 +99,13 @@ export function MacroplanNewDialog({
           mode={MacroplanFormMode.New}
           tripId={trip.id}
           tripTimeZone={trip.timeZone}
-          tripStartDateTime={tripStartDateTime}
-          tripEndDateTime={tripEndDateTime}
+          tripStartDate={tripStartDateTime}
+          tripEndDate={tripEndDateTime}
           macroplanName=""
-          macroplanDateStartDateTime={macroplanCheckInDateTime}
-          macroplanDateEndDateTime={macroplanCheckOutDateTime}
+          macroplanStartDate={macroplanStartDate}
+          macroplanEndDate={macroplanEndDate}
+          macroplanStartTimeZone={macroplanStartTimeZone}
+          macroplanEndTimeZone={macroplanEndTimeZone}
           macroplanNotes=""
           onFormCancel={popDialog}
           onFormSuccess={popDialog}

--- a/src/PageDemo.tsx
+++ b/src/PageDemo.tsx
@@ -1,16 +1,24 @@
-import { DateTime } from 'luxon';
 import { useState } from 'react';
 import { DateTimePicker } from './common/DatePicker2/DateTimePicker';
 
-const today = DateTime.fromISO('2025-06-07T09:10:00Z');
-const min = today.plus({ months: -1 });
-const max = today.plus({ months: 1 });
+const todayDate = Temporal.PlainDate.from('2025-06-07T09:10:00');
+const todayDateTime = Temporal.PlainDateTime.from('2025-06-07T09:10:00');
+const min = todayDate.add({ months: -1 });
+const max = todayDate.add({ months: 1 });
 
 export default function PageDemo() {
-  const [value, setValue] = useState<DateTime | undefined>(today);
-  const [value2, setValue2] = useState<DateTime | undefined>(today);
-  const [value3, setValue3] = useState<DateTime | undefined>(today);
-  const [value4, setValue4] = useState<DateTime | undefined>(today);
+  const [value, setValue] = useState<
+    Temporal.PlainDate | Temporal.PlainDateTime | undefined
+  >(todayDate);
+  const [value2, setValue2] = useState<
+    Temporal.PlainDate | Temporal.PlainDateTime | undefined
+  >(todayDate);
+  const [value3, setValue3] = useState<
+    Temporal.PlainDate | Temporal.PlainDateTime | undefined
+  >(todayDateTime);
+  const [value4, setValue4] = useState<
+    Temporal.PlainDate | Temporal.PlainDateTime | undefined
+  >(todayDateTime);
   return (
     <div>
       <div>

--- a/src/Trip/TripDialog/TripEditDialog.tsx
+++ b/src/Trip/TripDialog/TripEditDialog.tsx
@@ -1,5 +1,4 @@
 import { Box, Dialog } from '@radix-ui/themes';
-import { DateTime } from 'luxon';
 import { CommonLargeDialogMaxWidth } from '../../Dialog/ui';
 import { useBoundStore } from '../../data/store';
 import type { TripSliceTrip } from '../store/types';
@@ -7,12 +6,17 @@ import { TripForm } from '../TripForm';
 import { TripFormMode } from '../TripFormMode';
 
 export function TripEditDialog({ trip }: { trip: TripSliceTrip }) {
-  const tripStartDateTime = DateTime.fromMillis(trip.timestampStart).setZone(
-    trip.timeZone,
-  );
-  const tripEndDateTime = DateTime.fromMillis(trip.timestampEnd)
-    .setZone(trip.timeZone)
-    .minus({ days: 1 });
+  const tripStartDateTime = Temporal.Instant.fromEpochMilliseconds(
+    trip.timestampStart,
+  )
+    .toZonedDateTimeISO(trip.timeZone)
+    .toPlainDate();
+  const tripEndDateTime = Temporal.Instant.fromEpochMilliseconds(
+    trip.timestampEnd,
+  )
+    .toZonedDateTimeISO(trip.timeZone)
+    .toPlainDate()
+    .subtract({ days: 1 });
   const popDialog = useBoundStore((state) => state.popDialog);
 
   return (

--- a/src/Trip/TripForm.tsx
+++ b/src/Trip/TripForm.tsx
@@ -1,5 +1,4 @@
 import { Button, Flex, Select, Text, TextField } from '@radix-ui/themes';
-import type { DateTime } from 'luxon';
 import type { SubmitEvent } from 'react';
 import { useCallback, useId, useMemo, useState } from 'react';
 import { useLocation } from 'wouter';
@@ -43,8 +42,8 @@ export function TripForm({
 }: {
   mode: TripFormMode;
   tripId?: string;
-  tripStartDateTime: DateTime | undefined;
-  tripEndDateTime: DateTime | undefined;
+  tripStartDateTime: Temporal.PlainDate | undefined;
+  tripEndDateTime: Temporal.PlainDate | undefined;
   tripTitle: string;
   tripTimeZone: string;
   tripRegion: string;
@@ -69,56 +68,42 @@ export function TripForm({
   const [currentOriginCurrency, setCurrentOriginCurrency] =
     useState(tripOriginCurrency);
   const [currentStartDate, setCurrentStartDate] = useState<
-    DateTime | undefined
+    Temporal.PlainDate | undefined
   >(tripStartDateTime);
-  const [currentEndDate, setCurrentEndDate] = useState<DateTime | undefined>(
-    tripEndDateTime,
-  );
+  const [currentEndDate, setCurrentEndDate] = useState<
+    Temporal.PlainDate | undefined
+  >(tripEndDateTime);
 
   const [errorMessage, setErrorMessage] = useState('');
 
   // Handler for start date changes
   const handleStartDateChange = useCallback(
-    (dateTime: DateTime | undefined) => {
-      setCurrentStartDate(
-        dateTime?.setZone(currentTimeZone, { keepLocalTime: true }),
-      );
+    (date: Temporal.PlainDate | Temporal.PlainDateTime | undefined) => {
+      if (date instanceof Temporal.PlainDateTime) {
+        setCurrentStartDate(date.toPlainDate());
+      } else {
+        setCurrentStartDate(date);
+      }
     },
-    [currentTimeZone],
+    [],
   );
 
   // Handler for end date changes
   const handleEndDateChange = useCallback(
-    (dateTime: DateTime | undefined) => {
-      setCurrentEndDate(
-        dateTime?.setZone(currentTimeZone, { keepLocalTime: true }),
-      );
-    },
-    [currentTimeZone],
-  );
-
-  // Helper to update timezone on DateTime objects
-  const updateDateTimeZone = useCallback(
-    (dateTime: DateTime | undefined, newTimeZone: string) => {
-      if (!dateTime) return undefined;
-      return dateTime.setZone(newTimeZone, {
-        // "preserve" time relative to the date
-        keepLocalTime: true,
-      });
+    (date: Temporal.PlainDate | Temporal.PlainDateTime | undefined) => {
+      if (date instanceof Temporal.PlainDateTime) {
+        setCurrentEndDate(date.toPlainDate());
+      } else {
+        setCurrentEndDate(date);
+      }
     },
     [],
   );
 
   // Handler for timezone change
-  const handleTimeZoneChange = useCallback(
-    (newTimeZone: string) => {
-      setCurrentTimeZone(newTimeZone);
-      // Update existing dates to new timezone
-      setCurrentStartDate((prev) => updateDateTimeZone(prev, newTimeZone));
-      setCurrentEndDate((prev) => updateDateTimeZone(prev, newTimeZone));
-    },
-    [updateDateTimeZone],
-  );
+  const handleTimeZoneChange = useCallback((newTimeZone: string) => {
+    setCurrentTimeZone(newTimeZone);
+  }, []);
 
   // Handler for region change to auto-populate timezone
   const handleRegionChange = useCallback(
@@ -158,7 +143,7 @@ export function TripForm({
       const formData = new FormData(elForm);
       const title = (formData.get('title') as string | null) ?? '';
       const dateStartDateTime = currentStartDate;
-      const dateEndDateTime = currentEndDate?.plus({ day: 1 });
+      const dateEndDateTime = currentEndDate?.add({ days: 1 });
       const timeZone = currentTimeZone;
       const region = currentRegion;
       const currency = currentCurrency;
@@ -188,8 +173,9 @@ export function TripForm({
         setIsFormLoading(false);
         return;
       }
-      if (dateEndDateTime.diff(dateStartDateTime).as('minute') < 0) {
-        setErrorMessage('End date must be after start date');
+      // compare(date1, date2) returns 1 if date1 > date2, 0 if equal, -1 if date1 < date2
+      if (Temporal.PlainDate.compare(dateStartDateTime, dateEndDateTime) > 0) {
+        setErrorMessage('Start date cannot be after end date');
         setIsFormLoading(false);
         return;
       }
@@ -198,8 +184,11 @@ export function TripForm({
           id: tripId,
           title,
           timeZone,
-          timestampStart: dateStartDateTime.toMillis(),
-          timestampEnd: dateEndDateTime.toMillis(),
+          timestampStart: dateStartDateTime
+            .toZonedDateTime(timeZone)
+            .toInstant().epochMilliseconds,
+          timestampEnd: dateEndDateTime.toZonedDateTime(timeZone).toInstant()
+            .epochMilliseconds,
           region,
           currency,
           originCurrency,
@@ -218,8 +207,11 @@ export function TripForm({
           {
             title,
             timeZone,
-            timestampStart: dateStartDateTime.toMillis(),
-            timestampEnd: dateEndDateTime.toMillis(),
+            timestampStart: dateStartDateTime
+              .toZonedDateTime(timeZone)
+              .toInstant().epochMilliseconds,
+            timestampEnd: dateEndDateTime.toZonedDateTime(timeZone).toInstant()
+              .epochMilliseconds,
             region,
             currency,
             originCurrency,

--- a/src/Trip/TripForm.tsx
+++ b/src/Trip/TripForm.tsx
@@ -142,8 +142,8 @@ export function TripForm({
       }
       const formData = new FormData(elForm);
       const title = (formData.get('title') as string | null) ?? '';
-      const dateStartDateTime = currentStartDate;
-      const dateEndDateTime = currentEndDate?.add({ days: 1 });
+      const dateStartForDb = currentStartDate;
+      const dateEndForDb = currentEndDate?.add({ days: 1 });
       const timeZone = currentTimeZone;
       const region = currentRegion;
       const currency = currentCurrency;
@@ -158,13 +158,15 @@ export function TripForm({
         region,
         currency,
         originCurrency,
-        dateStartDateTime,
-        dateEndDateTime,
+        dateStartDateTime: dateStartForDb,
+        dateEndDateTime: dateEndForDb,
       });
       if (
         !title ||
-        !dateStartDateTime ||
-        !dateEndDateTime ||
+        !currentStartDate ||
+        !currentEndDate ||
+        !dateStartForDb ||
+        !dateEndForDb ||
         !timeZone ||
         !currency ||
         !originCurrency ||
@@ -174,7 +176,7 @@ export function TripForm({
         return;
       }
       // compare(date1, date2) returns 1 if date1 > date2, 0 if equal, -1 if date1 < date2
-      if (Temporal.PlainDate.compare(dateStartDateTime, dateEndDateTime) > 0) {
+      if (Temporal.PlainDate.compare(currentStartDate, currentEndDate) > 0) {
         setErrorMessage('Start date cannot be after end date');
         setIsFormLoading(false);
         return;
@@ -184,10 +186,9 @@ export function TripForm({
           id: tripId,
           title,
           timeZone,
-          timestampStart: dateStartDateTime
-            .toZonedDateTime(timeZone)
-            .toInstant().epochMilliseconds,
-          timestampEnd: dateEndDateTime.toZonedDateTime(timeZone).toInstant()
+          timestampStart: dateStartForDb.toZonedDateTime(timeZone).toInstant()
+            .epochMilliseconds,
+          timestampEnd: dateEndForDb.toZonedDateTime(timeZone).toInstant()
             .epochMilliseconds,
           region,
           currency,
@@ -207,10 +208,9 @@ export function TripForm({
           {
             title,
             timeZone,
-            timestampStart: dateStartDateTime
-              .toZonedDateTime(timeZone)
-              .toInstant().epochMilliseconds,
-            timestampEnd: dateEndDateTime.toZonedDateTime(timeZone).toInstant()
+            timestampStart: dateStartForDb.toZonedDateTime(timeZone).toInstant()
+              .epochMilliseconds,
+            timestampEnd: dateEndForDb.toZonedDateTime(timeZone).toInstant()
               .epochMilliseconds,
             region,
             currency,

--- a/src/Trip/TripNew/FlightSubform.tsx
+++ b/src/Trip/TripNew/FlightSubform.tsx
@@ -1,5 +1,4 @@
 import { Flex, Select, Text, TextField } from '@radix-ui/themes';
-import type { DateTime } from 'luxon';
 import {
   type ChangeEvent,
   type FocusEvent,
@@ -22,8 +21,8 @@ export type FlightSubformProps = {
   destinationTimeZone: string;
   isOutbound: boolean;
   error?: string;
-  tripStartDate: DateTime | undefined;
-  tripEndDate: DateTime | undefined;
+  tripStartDate: Temporal.PlainDate | undefined;
+  tripEndDate: Temporal.PlainDate | undefined;
   onChange: (flight: FlightCapture | null) => void;
 };
 
@@ -63,6 +62,22 @@ export function FlightSubform({
   const [editingArrivalTz, setEditingArrivalTz] = useState(false);
   const departureBadgeRef = useRef<HTMLButtonElement>(null);
   const arrivalBadgeRef = useRef<HTMLButtonElement>(null);
+  const minDepartureDate: Temporal.PlainDate | undefined = useMemo(() => {
+    if (!tripStartDate) return undefined;
+    return tripStartDate.subtract({ days: 1 });
+  }, [tripStartDate]);
+  const maxDepartureDate: Temporal.PlainDate | undefined = useMemo(() => {
+    if (!tripEndDate) return undefined;
+    return tripEndDate.add({ days: 1 });
+  }, [tripEndDate]);
+  const minArrivalDate: Temporal.PlainDate | undefined = useMemo(() => {
+    if (!tripStartDate) return undefined;
+    return tripStartDate.subtract({ days: 1 });
+  }, [tripStartDate]);
+  const maxArrivalDate: Temporal.PlainDate | undefined = useMemo(() => {
+    if (!tripEndDate) return undefined;
+    return tripEndDate.add({ days: 1 });
+  }, [tripEndDate]);
 
   const handleFlightNumberChange = useCallback(
     (e: ChangeEvent<HTMLInputElement>) =>
@@ -150,13 +165,37 @@ export function FlightSubform({
     [],
   );
   const handleDepartureDateChange = useCallback(
-    (date: DateTime | undefined) =>
-      onChange({ ...current, departureDateTime: date }),
+    (date: Temporal.PlainDate | Temporal.PlainDateTime | undefined) => {
+      return onChange({
+        ...current,
+        departureDateTime:
+          date instanceof Temporal.PlainDate
+            ? Temporal.PlainDateTime.from(date).with({
+                hour: 0,
+                minute: 0,
+                second: 0,
+                millisecond: 0,
+              })
+            : date,
+      });
+    },
     [current, onChange],
   );
   const handleArrivalDateChange = useCallback(
-    (date: DateTime | undefined) =>
-      onChange({ ...current, arrivalDateTime: date }),
+    (date: Temporal.PlainDate | Temporal.PlainDateTime | undefined) => {
+      return onChange({
+        ...current,
+        arrivalDateTime:
+          date instanceof Temporal.PlainDate
+            ? Temporal.PlainDateTime.from(date).with({
+                hour: 0,
+                minute: 0,
+                second: 0,
+                millisecond: 0,
+              })
+            : date,
+      });
+    },
     [current, onChange],
   );
 
@@ -236,8 +275,8 @@ export function FlightSubform({
             onChange={handleDepartureDateChange}
             mode={DateTimePickerMode.DateTime}
             placeholder="Pick date & time"
-            min={tripStartDate?.minus({ days: 1 })}
-            max={tripEndDate?.plus({ days: 1 })}
+            min={minDepartureDate}
+            max={maxDepartureDate}
           />
         </Flex>
 
@@ -276,8 +315,8 @@ export function FlightSubform({
             onChange={handleArrivalDateChange}
             mode={DateTimePickerMode.DateTime}
             placeholder="Pick date & time"
-            min={tripStartDate?.minus({ days: 1 })}
-            max={tripEndDate?.plus({ days: 1 })}
+            min={minArrivalDate}
+            max={maxArrivalDate}
           />
           {error !== undefined && (
             <Text size="1" color="red">

--- a/src/Trip/TripNew/FlightSubform.tsx
+++ b/src/Trip/TripNew/FlightSubform.tsx
@@ -39,25 +39,8 @@ export function FlightSubform({
 }: FlightSubformProps) {
   const defaultDepartureTz = isOutbound ? originTimeZone : destinationTimeZone;
   const defaultArrivalTz = isOutbound ? destinationTimeZone : originTimeZone;
-  const emptyFlight = useMemo<FlightCapture>(
-    () => ({
-      flightNumber: '',
-      departureAirport: '',
-      arrivalAirport: '',
-      departureDateTime: undefined,
-      arrivalDateTime: undefined,
-      departureTimeZone: defaultDepartureTz,
-      arrivalTimeZone: defaultArrivalTz,
-      departureLat: undefined,
-      departureLng: undefined,
-      departureZoom: undefined,
-      arrivalLat: undefined,
-      arrivalLng: undefined,
-      arrivalZoom: undefined,
-    }),
-    [defaultDepartureTz, defaultArrivalTz],
-  );
-  const current = value ?? emptyFlight;
+
+  const current = value;
   const [editingDepartureTz, setEditingDepartureTz] = useState(false);
   const [editingArrivalTz, setEditingArrivalTz] = useState(false);
   const departureBadgeRef = useRef<HTMLButtonElement>(null);
@@ -215,7 +198,7 @@ export function FlightSubform({
           <Text size="2">Flight number</Text>
           <TextField.Root
             placeholder="e.g. SQ321"
-            value={current.flightNumber}
+            value={current?.flightNumber ?? ''}
             onChange={handleFlightNumberChange}
           />
         </Flex>
@@ -224,7 +207,7 @@ export function FlightSubform({
           <Text size="2">Departure airport</Text>
           <TextField.Root
             placeholder="e.g. SYD or Sydney Airport"
-            value={current.departureAirport}
+            value={current?.departureAirport ?? ''}
             onChange={handleDepartureAirportChange}
             onBlur={handleDepartureAirportBlur}
           />
@@ -234,7 +217,7 @@ export function FlightSubform({
           <Text size="2">Arrival airport</Text>
           <TextField.Root
             placeholder="e.g. LHR or London Heathrow"
-            value={current.arrivalAirport}
+            value={current?.arrivalAirport ?? ''}
             onChange={handleArrivalAirportChange}
             onBlur={handleArrivalAirportBlur}
           />
@@ -246,7 +229,7 @@ export function FlightSubform({
             {editingDepartureTz ? (
               <Select.Root
                 defaultOpen
-                value={current.departureTimeZone}
+                value={current?.departureTimeZone ?? defaultDepartureTz}
                 onValueChange={handleDepartureTzChange}
                 onOpenChange={handleDepartureTzOpenChange}
               >
@@ -266,12 +249,12 @@ export function FlightSubform({
                 className={s.tzBadge}
                 onClick={handleOpenDepartureTzEdit}
               >
-                {current.departureTimeZone}
+                {current?.departureTimeZone ?? defaultDepartureTz}
               </button>
             )}
           </Flex>
           <DateTimePicker
-            value={current.departureDateTime}
+            value={current?.departureDateTime}
             onChange={handleDepartureDateChange}
             mode={DateTimePickerMode.DateTime}
             placeholder="Pick date & time"
@@ -286,7 +269,7 @@ export function FlightSubform({
             {editingArrivalTz ? (
               <Select.Root
                 defaultOpen
-                value={current.arrivalTimeZone}
+                value={current?.arrivalTimeZone ?? defaultArrivalTz}
                 onValueChange={handleArrivalTzChange}
                 onOpenChange={handleArrivalTzOpenChange}
               >
@@ -306,12 +289,12 @@ export function FlightSubform({
                 className={s.tzBadge}
                 onClick={handleOpenArrivalTzEdit}
               >
-                {current.arrivalTimeZone}
+                {current?.arrivalTimeZone ?? defaultArrivalTz}
               </button>
             )}
           </Flex>
           <DateTimePicker
-            value={current.arrivalDateTime}
+            value={current?.arrivalDateTime}
             onChange={handleArrivalDateChange}
             mode={DateTimePickerMode.DateTime}
             placeholder="Pick date & time"

--- a/src/Trip/TripNew/PageTripNew.tsx
+++ b/src/Trip/TripNew/PageTripNew.tsx
@@ -393,7 +393,7 @@ export default function PageTripNew() {
       const flight = flightCapture;
       // If user has set departure date, but has not set arrival date, set arrival date to same as departure date
       if (flight?.departureDateTime && !flight.arrivalDateTime) {
-        flight.arrivalDateTime = flight.departureDateTime;
+        flight.arrivalDateTime = flight.departureDateTime.add({ hours: 2 });
       }
       dispatch({ type: 'SET_OUTBOUND_FLIGHT', flight });
     },
@@ -403,7 +403,7 @@ export default function PageTripNew() {
     (flight: FlightCapture | null) => {
       // If use has set departure date, but has not set arrival date, set arrival date to same as departure date
       if (flight?.departureDateTime && !flight.arrivalDateTime) {
-        flight.arrivalDateTime = flight.departureDateTime;
+        flight.arrivalDateTime = flight.departureDateTime.add({ hours: 2 });
       }
       dispatch({ type: 'SET_RETURN_FLIGHT', flight });
     },

--- a/src/Trip/TripNew/PageTripNew.tsx
+++ b/src/Trip/TripNew/PageTripNew.tsx
@@ -15,6 +15,7 @@ import { dbAddActivity } from '../../Activity/db';
 import { CurrencySelect } from '../../common/CurrencySelect/CurrencySelect';
 import { DateTimePicker } from '../../common/DatePicker2/DateTimePicker';
 import { DateTimePickerMode } from '../../common/DatePicker2/DateTimePickerMode';
+import { toFormat } from '../../common/dateTime/temporalFormatter';
 import { TimeZoneSelect } from '../../common/TimeZoneSelect/TimeZoneSelect';
 import {
   ALL_CURRENCIES,
@@ -34,11 +35,10 @@ import s from './PageTripNew.module.css';
 import { WizardProgressDots } from './WizardProgressDots';
 import {
   createInitialWizardState,
-  wizardReducer,
   type FlightCapture,
+  wizardReducer,
 } from './wizardReducer';
 import { getFlightTimeError, getOriginCurrencyFromLocale } from './wizardUtils';
-import { toFormat } from '../../common/dateTime/temporalFormatter';
 
 export default function PageTripNew() {
   const [, setLocation] = useLocation();

--- a/src/Trip/TripNew/PageTripNew.tsx
+++ b/src/Trip/TripNew/PageTripNew.tsx
@@ -32,8 +32,13 @@ import { TripSharingLevel } from '../tripSharingLevel';
 import { FlightSubform } from './FlightSubform';
 import s from './PageTripNew.module.css';
 import { WizardProgressDots } from './WizardProgressDots';
-import { createInitialWizardState, wizardReducer } from './wizardReducer';
+import {
+  createInitialWizardState,
+  wizardReducer,
+  type FlightCapture,
+} from './wizardReducer';
 import { getFlightTimeError, getOriginCurrencyFromLocale } from './wizardUtils';
+import { toFormat } from '../../common/dateTime/temporalFormatter';
 
 export default function PageTripNew() {
   const [, setLocation] = useLocation();
@@ -90,6 +95,111 @@ export default function PageTripNew() {
     [state.region, handleRegionChange],
   );
 
+  const handleChangeStartDate = useCallback(
+    (date: Temporal.PlainDate | Temporal.PlainDateTime | undefined) => {
+      if (date instanceof Temporal.PlainDate) {
+        dispatch({ type: 'SET_START_DATE', date });
+      } else if (date instanceof Temporal.PlainDateTime) {
+        dispatch({ type: 'SET_START_DATE', date: date.toPlainDate() });
+      } else {
+        dispatch({ type: 'SET_START_DATE', date: undefined });
+      }
+
+      // If the end date has not been set, set it to the same as the start date
+      if (date instanceof Temporal.PlainDate && !state.endDate) {
+        dispatch({ type: 'SET_END_DATE', date });
+      }
+
+      // If user has not set outbound flight departure date, set it to the start date
+      if (
+        date instanceof Temporal.PlainDate &&
+        !state.outboundFlight?.departureDateTime
+      ) {
+        const newOutboundFlight = {
+          departureDateTime: Temporal.PlainDateTime.from({
+            year: date.year,
+            month: date.month,
+            day: date.day,
+            hour: 12, // Default to noon
+            minute: 0,
+          }),
+        };
+        dispatch({ type: 'SET_OUTBOUND_FLIGHT', flight: newOutboundFlight });
+      }
+
+      // If user has not set outbound flight arrival date, set it to the start date
+      if (
+        date instanceof Temporal.PlainDate &&
+        !state.outboundFlight?.arrivalDateTime
+      ) {
+        const newOutboundFlight = {
+          arrivalDateTime: Temporal.PlainDateTime.from({
+            year: date.year,
+            month: date.month,
+            day: date.day,
+            hour: 13,
+            minute: 0,
+          }),
+        };
+        dispatch({ type: 'SET_OUTBOUND_FLIGHT', flight: newOutboundFlight });
+      }
+    },
+    [
+      state.endDate,
+      state.outboundFlight?.arrivalDateTime,
+      state.outboundFlight?.departureDateTime,
+    ],
+  );
+  const handleChangeEndDate = useCallback(
+    (date: Temporal.PlainDate | Temporal.PlainDateTime | undefined) => {
+      if (date instanceof Temporal.PlainDate) {
+        dispatch({ type: 'SET_END_DATE', date });
+      } else if (date instanceof Temporal.PlainDateTime) {
+        dispatch({ type: 'SET_END_DATE', date: date.toPlainDate() });
+      } else {
+        dispatch({ type: 'SET_END_DATE', date: undefined });
+      }
+
+      // If user has not set return flight departure date, set it to the start date
+      if (
+        date instanceof Temporal.PlainDate &&
+        !state.returnFlight?.departureDateTime
+      ) {
+        const newReturnFlight = {
+          departureDateTime: Temporal.PlainDateTime.from({
+            year: date.year,
+            month: date.month,
+            day: date.day,
+            hour: 12, // Default to noon
+            minute: 0,
+          }),
+        };
+        dispatch({ type: 'SET_RETURN_FLIGHT', flight: newReturnFlight });
+      }
+
+      // If user has not set return flight arrival date, set it to the start date
+      if (
+        date instanceof Temporal.PlainDate &&
+        !state.returnFlight?.arrivalDateTime
+      ) {
+        const newReturnFlight = {
+          arrivalDateTime: Temporal.PlainDateTime.from({
+            year: date.year,
+            month: date.month,
+            day: date.day,
+            hour: 13,
+            minute: 0,
+          }),
+        };
+        dispatch({ type: 'SET_RETURN_FLIGHT', flight: newReturnFlight });
+      }
+    },
+    [
+      state.returnFlight?.departureDateTime,
+      state.returnFlight?.arrivalDateTime,
+    ],
+  );
+
   const handleCreateTrip = useCallback(async () => {
     const {
       startDate,
@@ -114,12 +224,19 @@ export default function PageTripNew() {
     }
     setIsSubmitting(true);
     try {
+      const timestampStart = startDate
+        .toZonedDateTime(timeZone)
+        .toInstant().epochMilliseconds;
+      const timestampEnd = endDate
+        .add({ days: 1 })
+        .toZonedDateTime(timeZone)
+        .toInstant().epochMilliseconds;
       const { id: newTripId } = await dbAddTrip(
         {
           title,
           timeZone,
-          timestampStart: startDate.toMillis(),
-          timestampEnd: endDate.plus({ days: 1 }).toMillis(),
+          timestampStart,
+          timestampEnd,
           region,
           currency,
           originCurrency,
@@ -129,15 +246,23 @@ export default function PageTripNew() {
       );
       const flightPromises: Promise<unknown>[] = [];
       if (
+        state.travelMode === 'flight' &&
         state.outboundFlight?.flightNumber &&
         state.outboundFlight?.departureDateTime &&
         state.outboundFlight?.arrivalDateTime
       ) {
+        const timestampStart = state.outboundFlight.departureDateTime
+          .toZonedDateTime(state.outboundFlight.departureTimeZone || timeZone)
+          .toInstant().epochMilliseconds;
+        const timestampEnd = state.outboundFlight.arrivalDateTime
+          .toZonedDateTime(state.outboundFlight.arrivalTimeZone || timeZone)
+          .toInstant().epochMilliseconds;
+
         flightPromises.push(
           dbAddActivity(
             {
               title: state.outboundFlight.flightNumber,
-              location: state.outboundFlight.departureAirport,
+              location: state.outboundFlight.departureAirport || '',
               locationLat: state.outboundFlight.departureLat,
               locationLng: state.outboundFlight.departureLng,
               locationZoom: state.outboundFlight.departureZoom,
@@ -146,16 +271,8 @@ export default function PageTripNew() {
               locationDestinationLng: state.outboundFlight.arrivalLng,
               locationDestinationZoom: state.outboundFlight.arrivalZoom,
               description: '',
-              timestampStart: state.outboundFlight.departureDateTime
-                .setZone(state.outboundFlight.departureTimeZone, {
-                  keepLocalTime: true,
-                })
-                .toMillis(),
-              timestampEnd: state.outboundFlight.arrivalDateTime
-                .setZone(state.outboundFlight.arrivalTimeZone, {
-                  keepLocalTime: true,
-                })
-                .toMillis(),
+              timestampStart,
+              timestampEnd,
               timeZoneStart: state.outboundFlight.departureTimeZone,
               timeZoneEnd: state.outboundFlight.arrivalTimeZone,
               flags: ActivityFlag.IsFlight,
@@ -166,15 +283,22 @@ export default function PageTripNew() {
         );
       }
       if (
+        state.travelMode === 'flight' &&
         state.returnFlight?.flightNumber &&
         state.returnFlight?.departureDateTime &&
         state.returnFlight?.arrivalDateTime
       ) {
+        const timestampStart = state.returnFlight.departureDateTime
+          .toZonedDateTime(state.returnFlight.departureTimeZone || timeZone)
+          .toInstant().epochMilliseconds;
+        const timestampEnd = state.returnFlight.arrivalDateTime
+          .toZonedDateTime(state.returnFlight.arrivalTimeZone || timeZone)
+          .toInstant().epochMilliseconds;
         flightPromises.push(
           dbAddActivity(
             {
               title: state.returnFlight.flightNumber,
-              location: state.returnFlight.departureAirport,
+              location: state.returnFlight.departureAirport || '',
               locationLat: state.returnFlight.departureLat,
               locationLng: state.returnFlight.departureLng,
               locationZoom: state.returnFlight.departureZoom,
@@ -183,16 +307,8 @@ export default function PageTripNew() {
               locationDestinationLng: state.returnFlight.arrivalLng,
               locationDestinationZoom: state.returnFlight.arrivalZoom,
               description: '',
-              timestampStart: state.returnFlight.departureDateTime
-                .setZone(state.returnFlight.departureTimeZone, {
-                  keepLocalTime: true,
-                })
-                .toMillis(),
-              timestampEnd: state.returnFlight.arrivalDateTime
-                .setZone(state.returnFlight.arrivalTimeZone, {
-                  keepLocalTime: true,
-                })
-                .toMillis(),
+              timestampStart,
+              timestampEnd,
               timeZoneStart: state.returnFlight.departureTimeZone,
               timeZoneEnd: state.returnFlight.arrivalTimeZone,
               flags: ActivityFlag.IsFlight,
@@ -233,7 +349,7 @@ export default function PageTripNew() {
   const dateError =
     state.startDate !== undefined &&
     state.endDate !== undefined &&
-    state.endDate < state.startDate
+    Temporal.PlainDate.compare(state.startDate, state.endDate) > 0
       ? 'End date must be on or after the start date'
       : undefined;
 
@@ -253,11 +369,13 @@ export default function PageTripNew() {
     state.outboundFlight,
     state.startDate,
     state.endDate,
+    state.timeZone,
   );
   const returnFlightError = getFlightTimeError(
     state.returnFlight,
     state.startDate,
     state.endDate,
+    state.timeZone,
   );
 
   const regionDisplayName = useMemo(() => {
@@ -268,8 +386,29 @@ export default function PageTripNew() {
 
   const dateRangeLabel = useMemo(() => {
     if (!state.startDate || !state.endDate) return '';
-    return `${state.startDate.toFormat('MMM d, yyyy')} – ${state.endDate.toFormat('MMM d, yyyy')}`;
+    return `${toFormat('d MMM yyyy', state.startDate)} – ${toFormat('d MMM yyyy', state.endDate)}`;
   }, [state.startDate, state.endDate]);
+  const handleOutboundFlightChange = useCallback(
+    (flightCapture: FlightCapture | null) => {
+      const flight = flightCapture;
+      // If user has set departure date, but has not set arrival date, set arrival date to same as departure date
+      if (flight?.departureDateTime && !flight.arrivalDateTime) {
+        flight.arrivalDateTime = flight.departureDateTime;
+      }
+      dispatch({ type: 'SET_OUTBOUND_FLIGHT', flight });
+    },
+    [],
+  );
+  const handleReturnFlightChange = useCallback(
+    (flight: FlightCapture | null) => {
+      // If use has set departure date, but has not set arrival date, set arrival date to same as departure date
+      if (flight?.departureDateTime && !flight.arrivalDateTime) {
+        flight.arrivalDateTime = flight.departureDateTime;
+      }
+      dispatch({ type: 'SET_RETURN_FLIGHT', flight });
+    },
+    [],
+  );
 
   if (state.step === 1) {
     return (
@@ -310,7 +449,7 @@ export default function PageTripNew() {
             </Text>
             <DateTimePicker
               value={state.startDate}
-              onChange={(date) => dispatch({ type: 'SET_START_DATE', date })}
+              onChange={handleChangeStartDate}
               mode={DateTimePickerMode.Date}
               name="startDate"
               required
@@ -324,7 +463,7 @@ export default function PageTripNew() {
             </Text>
             <DateTimePicker
               value={state.endDate}
-              onChange={(date) => dispatch({ type: 'SET_END_DATE', date })}
+              onChange={handleChangeEndDate}
               mode={DateTimePickerMode.Date}
               name="endDate"
               required
@@ -505,9 +644,7 @@ export default function PageTripNew() {
             error={outboundFlightError}
             tripStartDate={state.startDate}
             tripEndDate={state.endDate}
-            onChange={(flight) =>
-              dispatch({ type: 'SET_OUTBOUND_FLIGHT', flight })
-            }
+            onChange={handleOutboundFlightChange}
           />
           <FlightSubform
             label="Return flight"
@@ -518,9 +655,7 @@ export default function PageTripNew() {
             error={returnFlightError}
             tripStartDate={state.startDate}
             tripEndDate={state.endDate}
-            onChange={(flight) =>
-              dispatch({ type: 'SET_RETURN_FLIGHT', flight })
-            }
+            onChange={handleReturnFlightChange}
           />
         </>
       )}

--- a/src/Trip/TripNew/PageTripNew.tsx
+++ b/src/Trip/TripNew/PageTripNew.tsx
@@ -17,15 +17,7 @@ import { DateTimePicker } from '../../common/DatePicker2/DateTimePicker';
 import { DateTimePickerMode } from '../../common/DatePicker2/DateTimePickerMode';
 import { toFormat } from '../../common/dateTime/temporalFormatter';
 import { TimeZoneSelect } from '../../common/TimeZoneSelect/TimeZoneSelect';
-import {
-  ALL_CURRENCIES,
-  getDefaultCurrencyForRegion,
-} from '../../data/intl/currencies';
 import { REGIONS_LIST } from '../../data/intl/regions';
-import {
-  ALL_TIMEZONES,
-  getDefaultTimezoneForRegion,
-} from '../../data/intl/timezones';
 import { useBoundStore } from '../../data/store';
 import { RouteTrip, RouteTrips } from '../../Routes/routes';
 import { dbAddTrip } from '../db';
@@ -54,23 +46,12 @@ export default function PageTripNew() {
   const publishToast = useBoundStore((store) => store.publishToast);
   const currentUser = useBoundStore((store) => store.currentUser);
 
-  const handleRegionChange = useCallback(
-    (region: string) => {
-      const newTz = getDefaultTimezoneForRegion(region);
-      const newCurrency = getDefaultCurrencyForRegion(region);
-      dispatch({
-        type: 'SET_REGION',
-        region,
-        timeZone:
-          newTz && ALL_TIMEZONES.includes(newTz) ? newTz : state.timeZone,
-        currency:
-          newCurrency && ALL_CURRENCIES.includes(newCurrency)
-            ? newCurrency
-            : state.currency,
-      });
-    },
-    [state.timeZone, state.currency],
-  );
+  const handleRegionChange = useCallback((region: string) => {
+    dispatch({
+      type: 'SET_REGION',
+      region,
+    });
+  }, []);
 
   const idRegion = 'wizard-region';
 
@@ -104,51 +85,8 @@ export default function PageTripNew() {
       } else {
         dispatch({ type: 'SET_START_DATE', date: undefined });
       }
-
-      // If the end date has not been set, set it to the same as the start date
-      if (date instanceof Temporal.PlainDate && !state.endDate) {
-        dispatch({ type: 'SET_END_DATE', date });
-      }
-
-      // If user has not set outbound flight departure date, set it to the start date
-      if (
-        date instanceof Temporal.PlainDate &&
-        !state.outboundFlight?.departureDateTime
-      ) {
-        const newOutboundFlight = {
-          departureDateTime: Temporal.PlainDateTime.from({
-            year: date.year,
-            month: date.month,
-            day: date.day,
-            hour: 12, // Default to noon
-            minute: 0,
-          }),
-        };
-        dispatch({ type: 'SET_OUTBOUND_FLIGHT', flight: newOutboundFlight });
-      }
-
-      // If user has not set outbound flight arrival date, set it to the start date
-      if (
-        date instanceof Temporal.PlainDate &&
-        !state.outboundFlight?.arrivalDateTime
-      ) {
-        const newOutboundFlight = {
-          arrivalDateTime: Temporal.PlainDateTime.from({
-            year: date.year,
-            month: date.month,
-            day: date.day,
-            hour: 13,
-            minute: 0,
-          }),
-        };
-        dispatch({ type: 'SET_OUTBOUND_FLIGHT', flight: newOutboundFlight });
-      }
     },
-    [
-      state.endDate,
-      state.outboundFlight?.arrivalDateTime,
-      state.outboundFlight?.departureDateTime,
-    ],
+    [],
   );
   const handleChangeEndDate = useCallback(
     (date: Temporal.PlainDate | Temporal.PlainDateTime | undefined) => {
@@ -159,45 +97,8 @@ export default function PageTripNew() {
       } else {
         dispatch({ type: 'SET_END_DATE', date: undefined });
       }
-
-      // If user has not set return flight departure date, set it to the start date
-      if (
-        date instanceof Temporal.PlainDate &&
-        !state.returnFlight?.departureDateTime
-      ) {
-        const newReturnFlight = {
-          departureDateTime: Temporal.PlainDateTime.from({
-            year: date.year,
-            month: date.month,
-            day: date.day,
-            hour: 12, // Default to noon
-            minute: 0,
-          }),
-        };
-        dispatch({ type: 'SET_RETURN_FLIGHT', flight: newReturnFlight });
-      }
-
-      // If user has not set return flight arrival date, set it to the start date
-      if (
-        date instanceof Temporal.PlainDate &&
-        !state.returnFlight?.arrivalDateTime
-      ) {
-        const newReturnFlight = {
-          arrivalDateTime: Temporal.PlainDateTime.from({
-            year: date.year,
-            month: date.month,
-            day: date.day,
-            hour: 13,
-            minute: 0,
-          }),
-        };
-        dispatch({ type: 'SET_RETURN_FLIGHT', flight: newReturnFlight });
-      }
     },
-    [
-      state.returnFlight?.departureDateTime,
-      state.returnFlight?.arrivalDateTime,
-    ],
+    [],
   );
 
   const handleCreateTrip = useCallback(async () => {

--- a/src/Trip/TripNew/wizardReducer.test.ts
+++ b/src/Trip/TripNew/wizardReducer.test.ts
@@ -1,5 +1,3 @@
-// src/Trip/TripNew/wizardReducer.test.ts
-import { DateTime } from 'luxon';
 import { describe, expect, test } from 'vitest';
 import {
   createInitialWizardState,
@@ -71,20 +69,6 @@ describe('wizardReducer', () => {
     expect(next.title).toBe('My Trip');
   });
 
-  test('SET_START_DATE updates startDate (normalized to wizard timeZone)', () => {
-    const date = DateTime.fromISO('2026-10-01', { zone: 'UTC' });
-    const next = wizardReducer(BASE, { type: 'SET_START_DATE', date });
-    const expected = date.setZone('Asia/Tokyo', { keepLocalTime: true });
-    expect(next.startDate?.toISO()).toBe(expected.toISO());
-  });
-
-  test('SET_END_DATE updates endDate (normalized to wizard timeZone)', () => {
-    const date = DateTime.fromISO('2026-10-10', { zone: 'UTC' });
-    const next = wizardReducer(BASE, { type: 'SET_END_DATE', date });
-    const expected = date.setZone('Asia/Tokyo', { keepLocalTime: true });
-    expect(next.endDate?.toISO()).toBe(expected.toISO());
-  });
-
   test('SET_TIMEZONE updates timeZone', () => {
     const next = wizardReducer(BASE, {
       type: 'SET_TIMEZONE',
@@ -131,8 +115,8 @@ describe('wizardReducer', () => {
       flightNumber: 'SQ321',
       departureAirport: 'SYD',
       arrivalAirport: 'NRT',
-      departureDateTime: DateTime.fromISO('2026-10-01T08:00'),
-      arrivalDateTime: DateTime.fromISO('2026-10-01T16:00'),
+      departureDateTime: Temporal.PlainDateTime.from('2026-10-01T08:00'),
+      arrivalDateTime: Temporal.PlainDateTime.from('2026-10-01T16:00'),
       departureTimeZone: 'America/New_York',
       arrivalTimeZone: 'Asia/Tokyo',
       departureLat: undefined,
@@ -177,8 +161,8 @@ describe('wizardReducer', () => {
       flightNumber: 'SQ322',
       departureAirport: 'NRT',
       arrivalAirport: 'SYD',
-      departureDateTime: DateTime.fromISO('2026-10-10T18:00'),
-      arrivalDateTime: DateTime.fromISO('2026-10-11T02:00'),
+      departureDateTime: Temporal.PlainDateTime.from('2026-10-10T18:00'),
+      arrivalDateTime: Temporal.PlainDateTime.from('2026-10-11T02:00'),
       departureTimeZone: 'Asia/Tokyo',
       arrivalTimeZone: 'America/New_York',
       departureLat: undefined,

--- a/src/Trip/TripNew/wizardReducer.test.ts
+++ b/src/Trip/TripNew/wizardReducer.test.ts
@@ -127,7 +127,7 @@ describe('wizardReducer', () => {
       arrivalZoom: undefined,
     };
     const next = wizardReducer(BASE, { type: 'SET_OUTBOUND_FLIGHT', flight });
-    expect(next.outboundFlight).toBe(flight);
+    expect(next.outboundFlight).toStrictEqual(flight);
   });
 
   test('SET_OUTBOUND_FLIGHT can be cleared to null', () => {
@@ -173,7 +173,7 @@ describe('wizardReducer', () => {
       arrivalZoom: undefined,
     };
     const next = wizardReducer(BASE, { type: 'SET_RETURN_FLIGHT', flight });
-    expect(next.returnFlight).toBe(flight);
+    expect(next.returnFlight).toStrictEqual(flight);
   });
 
   test('reducer is pure — does not mutate state', () => {

--- a/src/Trip/TripNew/wizardReducer.test.ts
+++ b/src/Trip/TripNew/wizardReducer.test.ts
@@ -47,8 +47,6 @@ describe('wizardReducer', () => {
     const next = wizardReducer(BASE, {
       type: 'SET_REGION',
       region: 'JP',
-      timeZone: 'Asia/Tokyo',
-      currency: 'JPY',
     });
     expect(next.region).toBe('JP');
     expect(next.timeZone).toBe('Asia/Tokyo');
@@ -63,8 +61,6 @@ describe('wizardReducer', () => {
     const next = wizardReducer(withTitle, {
       type: 'SET_REGION',
       region: 'JP',
-      timeZone: 'Asia/Tokyo',
-      currency: 'JPY',
     });
     expect(next.title).toBe('My Trip');
   });

--- a/src/Trip/TripNew/wizardReducer.ts
+++ b/src/Trip/TripNew/wizardReducer.ts
@@ -1,22 +1,19 @@
 // src/Trip/TripNew/wizardReducer.ts
-import type { DateTime } from 'luxon';
 
 export type FlightCapture = {
-  flightNumber: string;
-  departureAirport: string;
-  arrivalAirport: string;
-  /** "wall clock" state, when turn to ms, need to set zone + keep local times */
-  departureDateTime: DateTime | undefined;
-  /** "wall clock" state, when turn to ms, need to set zone + keep local times */
-  arrivalDateTime: DateTime | undefined;
-  departureTimeZone: string;
-  arrivalTimeZone: string;
-  departureLat: number | undefined;
-  departureLng: number | undefined;
-  departureZoom: number | undefined;
-  arrivalLat: number | undefined;
-  arrivalLng: number | undefined;
-  arrivalZoom: number | undefined;
+  flightNumber?: string | undefined;
+  departureAirport?: string | undefined;
+  arrivalAirport?: string | undefined;
+  departureDateTime?: Temporal.PlainDateTime | undefined;
+  arrivalDateTime?: Temporal.PlainDateTime | undefined;
+  departureTimeZone?: string | undefined;
+  arrivalTimeZone?: string | undefined;
+  departureLat?: number | undefined;
+  departureLng?: number | undefined;
+  departureZoom?: number | undefined;
+  arrivalLat?: number | undefined;
+  arrivalLng?: number | undefined;
+  arrivalZoom?: number | undefined;
 };
 
 export type WizardState = {
@@ -24,8 +21,8 @@ export type WizardState = {
   // Step 1
   title: string;
   region: string;
-  startDate: DateTime | undefined;
-  endDate: DateTime | undefined;
+  startDate: Temporal.PlainDate | undefined;
+  endDate: Temporal.PlainDate | undefined;
   // Step 2 (pre-filled from region)
   timeZone: string;
   currency: string;
@@ -40,8 +37,8 @@ export type WizardAction =
   | { type: 'SET_STEP'; step: 1 | 2 | 3 }
   | { type: 'SET_TITLE'; title: string }
   | { type: 'SET_REGION'; region: string; timeZone: string; currency: string }
-  | { type: 'SET_START_DATE'; date: DateTime | undefined }
-  | { type: 'SET_END_DATE'; date: DateTime | undefined }
+  | { type: 'SET_START_DATE'; date: Temporal.PlainDate | undefined }
+  | { type: 'SET_END_DATE'; date: Temporal.PlainDate | undefined }
   | { type: 'SET_TIMEZONE'; timeZone: string }
   | { type: 'SET_CURRENCY'; currency: string }
   | { type: 'SET_ORIGIN_CURRENCY'; originCurrency: string }
@@ -65,33 +62,27 @@ export function wizardReducer(
         region: action.region,
         timeZone: nextTimeZone,
         currency: action.currency,
-        startDate: state.startDate?.setZone(nextTimeZone, {
-          keepLocalTime: true,
-        }),
-        endDate: state.endDate?.setZone(nextTimeZone, { keepLocalTime: true }),
+        startDate: state.startDate,
+        endDate: state.endDate,
       };
     }
     case 'SET_START_DATE':
       return {
         ...state,
-        startDate: action.date?.setZone(state.timeZone, {
-          keepLocalTime: true,
-        }),
+        startDate: action.date,
       };
     case 'SET_END_DATE':
       return {
         ...state,
-        endDate: action.date?.setZone(state.timeZone, { keepLocalTime: true }),
+        endDate: action.date,
       };
     case 'SET_TIMEZONE': {
       const nextTimeZone = action.timeZone;
       return {
         ...state,
         timeZone: nextTimeZone,
-        startDate: state.startDate?.setZone(nextTimeZone, {
-          keepLocalTime: true,
-        }),
-        endDate: state.endDate?.setZone(nextTimeZone, { keepLocalTime: true }),
+        startDate: state.startDate,
+        endDate: state.endDate,
       };
     }
     case 'SET_CURRENCY':
@@ -101,9 +92,15 @@ export function wizardReducer(
     case 'SET_TRAVEL_MODE':
       return { ...state, travelMode: action.travelMode };
     case 'SET_OUTBOUND_FLIGHT':
-      return { ...state, outboundFlight: action.flight };
+      return {
+        ...state,
+        outboundFlight: { ...(state.outboundFlight || {}), ...action.flight },
+      };
     case 'SET_RETURN_FLIGHT':
-      return { ...state, returnFlight: action.flight };
+      return {
+        ...state,
+        returnFlight: { ...(state.returnFlight || {}), ...action.flight },
+      };
     default:
       return state;
   }

--- a/src/Trip/TripNew/wizardReducer.ts
+++ b/src/Trip/TripNew/wizardReducer.ts
@@ -1,4 +1,11 @@
-// src/Trip/TripNew/wizardReducer.ts
+import {
+  ALL_CURRENCIES,
+  getDefaultCurrencyForRegion,
+} from '../../data/intl/currencies';
+import {
+  ALL_TIMEZONES,
+  getDefaultTimezoneForRegion,
+} from '../../data/intl/timezones';
 
 export type FlightCapture = {
   flightNumber?: string | undefined;
@@ -36,7 +43,7 @@ export type WizardState = {
 export type WizardAction =
   | { type: 'SET_STEP'; step: 1 | 2 | 3 }
   | { type: 'SET_TITLE'; title: string }
-  | { type: 'SET_REGION'; region: string; timeZone: string; currency: string }
+  | { type: 'SET_REGION'; region: string }
   | { type: 'SET_START_DATE'; date: Temporal.PlainDate | undefined }
   | { type: 'SET_END_DATE'; date: Temporal.PlainDate | undefined }
   | { type: 'SET_TIMEZONE'; timeZone: string }
@@ -50,23 +57,73 @@ export function wizardReducer(
   state: WizardState,
   action: WizardAction,
 ): WizardState {
+  console.log('wizardReducer action:', action, 'prev state:', state);
   switch (action.type) {
     case 'SET_STEP':
+      if (state.step === 2 && action.step === 3) {
+        // When moving from step 2 to 3, pre-fill outbound flight and return flight with default values based on the trip's start and end dates
+        const currentTimeZone = Temporal.Now.timeZoneId();
+        const defaultOutboundFlight: FlightCapture = {
+          departureDateTime: state.startDate?.toPlainDateTime({
+            hour: 9,
+            minute: 0,
+          }),
+          arrivalDateTime: state.startDate?.toPlainDateTime({
+            hour: 12,
+            minute: 0,
+          }),
+          departureTimeZone: currentTimeZone,
+          arrivalTimeZone: state.timeZone,
+        };
+        const defaultReturnFlight: FlightCapture = {
+          departureDateTime: state.endDate?.toPlainDateTime({
+            hour: 15,
+            minute: 0,
+          }),
+          arrivalDateTime: state.endDate?.toPlainDateTime({
+            hour: 18,
+            minute: 0,
+          }),
+          departureTimeZone: state.timeZone,
+          arrivalTimeZone: currentTimeZone,
+        };
+        return {
+          ...state,
+          step: action.step,
+          outboundFlight: defaultOutboundFlight,
+          returnFlight: defaultReturnFlight,
+        };
+      }
+
       return { ...state, step: action.step };
     case 'SET_TITLE':
       return { ...state, title: action.title };
     case 'SET_REGION': {
-      const nextTimeZone = action.timeZone;
+      const newTz = getDefaultTimezoneForRegion(action.region);
+      const newCurrency = getDefaultCurrencyForRegion(action.region);
+
       return {
         ...state,
         region: action.region,
-        timeZone: nextTimeZone,
-        currency: action.currency,
+        timeZone:
+          newTz && ALL_TIMEZONES.includes(newTz) ? newTz : state.timeZone,
+        currency:
+          newCurrency && ALL_CURRENCIES.includes(newCurrency)
+            ? newCurrency
+            : state.currency,
         startDate: state.startDate,
         endDate: state.endDate,
       };
     }
     case 'SET_START_DATE':
+      // if user has not set the end date yet, we can auto-set it to the same day as the start date
+      if (!state.endDate) {
+        return {
+          ...state,
+          startDate: action.date,
+          endDate: action.date,
+        };
+      }
       return {
         ...state,
         startDate: action.date,

--- a/src/Trip/TripNew/wizardReducer.ts
+++ b/src/Trip/TripNew/wizardReducer.ts
@@ -61,38 +61,54 @@ export function wizardReducer(
   switch (action.type) {
     case 'SET_STEP':
       if (state.step === 2 && action.step === 3) {
-        // When moving from step 2 to 3, pre-fill outbound flight and return flight with default values based on the trip's start and end dates
+        // When moving from step 2 to 3, pre-fill outbound flight and return flight with default values based on the trip's start and end dates only if it has not been set yet
         const currentTimeZone = Temporal.Now.timeZoneId();
-        const defaultOutboundFlight: FlightCapture = {
-          departureDateTime: state.startDate?.toPlainDateTime({
-            hour: 9,
-            minute: 0,
-          }),
-          arrivalDateTime: state.startDate?.toPlainDateTime({
-            hour: 12,
-            minute: 0,
-          }),
-          departureTimeZone: currentTimeZone,
-          arrivalTimeZone: state.timeZone,
-        };
-        const defaultReturnFlight: FlightCapture = {
-          departureDateTime: state.endDate?.toPlainDateTime({
-            hour: 15,
-            minute: 0,
-          }),
-          arrivalDateTime: state.endDate?.toPlainDateTime({
-            hour: 18,
-            minute: 0,
-          }),
-          departureTimeZone: state.timeZone,
-          arrivalTimeZone: currentTimeZone,
-        };
-        return {
-          ...state,
-          step: action.step,
-          outboundFlight: defaultOutboundFlight,
-          returnFlight: defaultReturnFlight,
-        };
+        let newState = { ...state, step: action.step };
+        if (!state.outboundFlight && state.startDate) {
+          const zonedDepartureDateTime = state.startDate
+            .toPlainDateTime({
+              hour: 9,
+              minute: 0,
+            })
+            .toZonedDateTime(state.timeZone);
+          const zonedArrivalDateTime = zonedDepartureDateTime
+            .with({
+              hour: 12,
+              minute: 0,
+            })
+            .withTimeZone(currentTimeZone);
+
+          const defaultOutboundFlight: FlightCapture = {
+            departureDateTime: zonedDepartureDateTime.toPlainDateTime(),
+            arrivalDateTime: zonedArrivalDateTime.toPlainDateTime(),
+            departureTimeZone: currentTimeZone,
+            arrivalTimeZone: state.timeZone,
+          };
+          newState = { ...newState, outboundFlight: defaultOutboundFlight };
+        }
+        if (!state.returnFlight && state.endDate) {
+          const zonedDepartureDateTime = state.endDate
+            .toPlainDateTime({
+              hour: 15,
+              minute: 0,
+            })
+            .toZonedDateTime(state.timeZone);
+          const zonedArrivalDateTime = zonedDepartureDateTime
+            .with({
+              hour: 18,
+              minute: 0,
+            })
+            .withTimeZone(currentTimeZone);
+
+          const defaultReturnFlight: FlightCapture = {
+            departureDateTime: zonedDepartureDateTime.toPlainDateTime(),
+            arrivalDateTime: zonedArrivalDateTime.toPlainDateTime(),
+            departureTimeZone: state.timeZone,
+            arrivalTimeZone: currentTimeZone,
+          };
+          newState = { ...newState, returnFlight: defaultReturnFlight };
+        }
+        return newState;
       }
 
       return { ...state, step: action.step };

--- a/src/Trip/TripNew/wizardReducer.ts
+++ b/src/Trip/TripNew/wizardReducer.ts
@@ -92,11 +92,19 @@ export function wizardReducer(
     case 'SET_TRAVEL_MODE':
       return { ...state, travelMode: action.travelMode };
     case 'SET_OUTBOUND_FLIGHT':
+      // Clear the outbound flight if the action specifies null; else merge it
+      if (action.flight === null) {
+        return { ...state, outboundFlight: null };
+      }
       return {
         ...state,
         outboundFlight: { ...(state.outboundFlight || {}), ...action.flight },
       };
     case 'SET_RETURN_FLIGHT':
+      // Clear the return flight if the action specifies null; else merge it
+      if (action.flight === null) {
+        return { ...state, returnFlight: null };
+      }
       return {
         ...state,
         returnFlight: { ...(state.returnFlight || {}), ...action.flight },

--- a/src/Trip/TripNew/wizardUtils.ts
+++ b/src/Trip/TripNew/wizardUtils.ts
@@ -21,7 +21,7 @@ export function getFlightTimeError(
     ?.subtract({ days: 1 })
     .toZonedDateTime(tripTimeZone ?? Temporal.Now.timeZoneId());
   const maxBound = tripEndDate
-    ?.add({ days: 1 })
+    ?.add({ days: 2 })
     .toZonedDateTime(tripTimeZone ?? Temporal.Now.timeZoneId());
   if (dep && minBound && Temporal.ZonedDateTime.compare(dep, minBound) < 0)
     return 'Departure cannot be more than 1 day before trip start';

--- a/src/Trip/TripNew/wizardUtils.ts
+++ b/src/Trip/TripNew/wizardUtils.ts
@@ -1,25 +1,31 @@
-import type { DateTime } from 'luxon';
 import { getDefaultCurrencyForRegion } from '../../data/intl/currencies';
 import type { FlightCapture } from './wizardReducer';
 
 export function getFlightTimeError(
   flight: FlightCapture | null,
-  tripStartDate: DateTime | undefined,
-  tripEndDate: DateTime | undefined,
+  tripStartDate: Temporal.PlainDate | undefined,
+  tripEndDate: Temporal.PlainDate | undefined,
+  tripTimeZone: string | undefined,
 ): string | undefined {
   if (!flight?.departureDateTime && !flight?.arrivalDateTime) return undefined;
-  const dep = flight.departureDateTime?.setZone(flight.departureTimeZone, {
-    keepLocalTime: true,
-  });
-  const arr = flight.arrivalDateTime?.setZone(flight.arrivalTimeZone, {
-    keepLocalTime: true,
-  });
-  if (dep && arr && arr <= dep) return 'Arrival must be after departure';
-  const minBound = tripStartDate?.minus({ days: 1 });
-  const maxBound = tripEndDate?.plus({ days: 1 });
-  if (dep && minBound && dep < minBound)
+  const dep = flight.departureDateTime?.toZonedDateTime(
+    flight.departureTimeZone ?? tripTimeZone ?? Temporal.Now.timeZoneId(),
+  );
+  const arr = flight.arrivalDateTime?.toZonedDateTime(
+    flight.arrivalTimeZone ?? tripTimeZone ?? Temporal.Now.timeZoneId(),
+  );
+  if (dep && arr && Temporal.ZonedDateTime.compare(arr, dep) <= 0)
+    return 'Arrival must be after departure';
+
+  const minBound = tripStartDate
+    ?.subtract({ days: 1 })
+    .toZonedDateTime(tripTimeZone ?? Temporal.Now.timeZoneId());
+  const maxBound = tripEndDate
+    ?.add({ days: 1 })
+    .toZonedDateTime(tripTimeZone ?? Temporal.Now.timeZoneId());
+  if (dep && minBound && Temporal.ZonedDateTime.compare(dep, minBound) < 0)
     return 'Departure cannot be more than 1 day before trip start';
-  if (arr && maxBound && arr > maxBound)
+  if (arr && maxBound && Temporal.ZonedDateTime.compare(arr, maxBound) > 0)
     return 'Arrival cannot be more than 1 day after trip end';
   return undefined;
 }

--- a/src/Trip/TripTask/TaskDialog/TaskDialogContentEdit.tsx
+++ b/src/Trip/TripTask/TaskDialog/TaskDialogContentEdit.tsx
@@ -1,5 +1,4 @@
 import { Box, Dialog, Spinner } from '@radix-ui/themes';
-import { DateTime } from 'luxon';
 import { useCallback } from 'react';
 import type { DialogContentProps } from '../../../Dialog/DialogRoute';
 import { useTrip, useTripTaskList } from '../../store/hooks';
@@ -39,7 +38,9 @@ export function TaskDialogContentEdit({
           taskStatus={task.status}
           taskDueAtDateTime={
             task.dueAt
-              ? DateTime.fromMillis(task.dueAt).setZone(trip.timeZone)
+              ? Temporal.Instant.fromEpochMilliseconds(task.dueAt)
+                  .toZonedDateTimeISO(trip.timeZone)
+                  .toPlainDateTime()
               : undefined
           }
           taskIndex={task.index}

--- a/src/Trip/TripTask/TaskForm/TaskForm.tsx
+++ b/src/Trip/TripTask/TaskForm/TaskForm.tsx
@@ -6,7 +6,6 @@ import {
   TextArea,
   TextField,
 } from '@radix-ui/themes';
-import { DateTime } from 'luxon';
 import { useCallback, useId, useState } from 'react';
 import { DateTimePicker } from '../../../common/DatePicker2/DateTimePicker';
 import { DateTimePickerMode } from '../../../common/DatePicker2/DateTimePickerMode';
@@ -36,7 +35,7 @@ export function TaskForm({
   taskTitle: string;
   taskDescription: string;
   taskStatus: number;
-  taskDueAtDateTime?: DateTime | null | undefined;
+  taskDueAtDateTime?: Temporal.PlainDateTime | null | undefined;
   taskIndex?: number;
   onFormSuccess: () => void;
   onFormCancel: () => void;
@@ -51,24 +50,26 @@ export function TaskForm({
   const [isSubmitting, setIsSubmitting] = useState(false);
 
   // State for DateTime picker
-  const [dueAtDateTime, setDueAtDateTime] = useState<DateTime | undefined>(
-    taskDueAtDateTime || undefined,
-  );
+  const [dueAtDateTime, setDueAtDateTime] = useState<
+    Temporal.PlainDateTime | undefined
+  >(taskDueAtDateTime || undefined);
   const handleDueAtChange = useCallback(
     (value: Temporal.PlainDate | Temporal.PlainDateTime | undefined) => {
       if (value instanceof Temporal.PlainDateTime) {
-        setDueAtDateTime(DateTime.fromISO(value.toString()));
+        setDueAtDateTime(value);
       } else if (value instanceof Temporal.PlainDate) {
         // If only a date is selected, set the time to 00:00 in the trip's time zone
-        const dateTimeInTripTZ = DateTime.fromISO(value.toString(), {
-          zone: tripTimeZone,
-        }).startOf('day');
-        setDueAtDateTime(dateTimeInTripTZ);
+        setDueAtDateTime(
+          value.toPlainDateTime({
+            hour: 0,
+            minute: 0,
+          }),
+        );
       } else {
         setDueAtDateTime(undefined);
       }
     },
-    [tripTimeZone],
+    [],
   );
 
   const handleSubmit = useCallback(
@@ -88,7 +89,9 @@ export function TaskForm({
         return;
       }
 
-      const dueAt = dueAtDateTime ? dueAtDateTime.toMillis() : null;
+      const dueAt = dueAtDateTime
+        ? dueAtDateTime.toZonedDateTime(tripTimeZone).epochMilliseconds
+        : null;
 
       try {
         if (mode === TaskFormMode.New) {
@@ -150,6 +153,7 @@ export function TaskForm({
       taskIndex,
       publishToast,
       onFormSuccess,
+      tripTimeZone,
       dueAtDateTime,
     ],
   );
@@ -203,7 +207,7 @@ export function TaskForm({
         <DateTimePicker
           name="dueAt"
           mode={DateTimePickerMode.DateTime}
-          value={Temporal.PlainDate.from(dueAtDateTime?.toISO() || '')}
+          value={dueAtDateTime}
           onChange={handleDueAtChange}
           clearable
         />

--- a/src/Trip/TripTask/TaskForm/TaskForm.tsx
+++ b/src/Trip/TripTask/TaskForm/TaskForm.tsx
@@ -6,7 +6,7 @@ import {
   TextArea,
   TextField,
 } from '@radix-ui/themes';
-import type { DateTime } from 'luxon';
+import { DateTime } from 'luxon';
 import { useCallback, useId, useState } from 'react';
 import { DateTimePicker } from '../../../common/DatePicker2/DateTimePicker';
 import { DateTimePickerMode } from '../../../common/DatePicker2/DateTimePickerMode';
@@ -53,6 +53,22 @@ export function TaskForm({
   // State for DateTime picker
   const [dueAtDateTime, setDueAtDateTime] = useState<DateTime | undefined>(
     taskDueAtDateTime || undefined,
+  );
+  const handleDueAtChange = useCallback(
+    (value: Temporal.PlainDate | Temporal.PlainDateTime | undefined) => {
+      if (value instanceof Temporal.PlainDateTime) {
+        setDueAtDateTime(DateTime.fromISO(value.toString()));
+      } else if (value instanceof Temporal.PlainDate) {
+        // If only a date is selected, set the time to 00:00 in the trip's time zone
+        const dateTimeInTripTZ = DateTime.fromISO(value.toString(), {
+          zone: tripTimeZone,
+        }).startOf('day');
+        setDueAtDateTime(dateTimeInTripTZ);
+      } else {
+        setDueAtDateTime(undefined);
+      }
+    },
+    [tripTimeZone],
   );
 
   const handleSubmit = useCallback(
@@ -187,8 +203,8 @@ export function TaskForm({
         <DateTimePicker
           name="dueAt"
           mode={DateTimePickerMode.DateTime}
-          value={dueAtDateTime}
-          onChange={setDueAtDateTime}
+          value={Temporal.PlainDate.from(dueAtDateTime?.toISO() || '')}
+          onChange={handleDueAtChange}
           clearable
         />
 

--- a/src/Trip/getTripStatus.ts
+++ b/src/Trip/getTripStatus.ts
@@ -108,33 +108,15 @@ export function getTripStatus(
   // TODO: Convert everything to Temporal in the future; for now reuse Luxon DateTime logic
   const tripStart =
     tripStartMaybe instanceof Temporal.ZonedDateTime
-      ? DateTime.fromObject(
-          {
-            year: tripStartMaybe.year,
-            month: tripStartMaybe.month,
-            day: tripStartMaybe.day,
-            hour: tripStartMaybe.hour,
-            minute: tripStartMaybe.minute,
-            second: tripStartMaybe.second,
-            millisecond: tripStartMaybe.millisecond,
-          },
-          { zone: tripStartMaybe.timeZoneId },
-        )
+      ? DateTime.fromMillis(tripStartMaybe.epochMilliseconds, {
+          zone: tripStartMaybe.timeZoneId,
+        })
       : tripStartMaybe;
   const tripEnd =
     tripEndMaybe instanceof Temporal.ZonedDateTime
-      ? DateTime.fromObject(
-          {
-            year: tripEndMaybe.year,
-            month: tripEndMaybe.month,
-            day: tripEndMaybe.day,
-            hour: tripEndMaybe.hour,
-            minute: tripEndMaybe.minute,
-            second: tripEndMaybe.second,
-            millisecond: tripEndMaybe.millisecond,
-          },
-          { zone: tripEndMaybe.timeZoneId },
-        )
+      ? DateTime.fromMillis(tripEndMaybe.epochMilliseconds, {
+          zone: tripEndMaybe.timeZoneId,
+        })
       : tripEndMaybe;
 
   const now = DateTime.now();

--- a/src/Trip/getTripStatus.ts
+++ b/src/Trip/getTripStatus.ts
@@ -100,8 +100,43 @@ function formatTimeParts(
  * @param tripEnd DateTime of day _after_ of trip end. This means the final full day of trip is one day before `timestampEnd`
  * @returns
  */
-export function getTripStatus(tripStart?: DateTime, tripEnd?: DateTime) {
-  if (!tripStart || !tripEnd) return null;
+export function getTripStatus(
+  tripStartMaybe?: DateTime | Temporal.ZonedDateTime,
+  tripEndMaybe?: DateTime | Temporal.ZonedDateTime,
+) {
+  if (!tripStartMaybe || !tripEndMaybe) return null;
+  // TODO: Convert everything to Temporal in the future; for now reuse Luxon DateTime logic
+  const tripStart =
+    tripStartMaybe instanceof Temporal.ZonedDateTime
+      ? DateTime.fromObject(
+          {
+            year: tripStartMaybe.year,
+            month: tripStartMaybe.month,
+            day: tripStartMaybe.day,
+            hour: tripStartMaybe.hour,
+            minute: tripStartMaybe.minute,
+            second: tripStartMaybe.second,
+            millisecond: tripStartMaybe.millisecond,
+          },
+          { zone: tripStartMaybe.timeZoneId },
+        )
+      : tripStartMaybe;
+  const tripEnd =
+    tripEndMaybe instanceof Temporal.ZonedDateTime
+      ? DateTime.fromObject(
+          {
+            year: tripEndMaybe.year,
+            month: tripEndMaybe.month,
+            day: tripEndMaybe.day,
+            hour: tripEndMaybe.hour,
+            minute: tripEndMaybe.minute,
+            second: tripEndMaybe.second,
+            millisecond: tripEndMaybe.millisecond,
+          },
+          { zone: tripEndMaybe.timeZoneId },
+        )
+      : tripEndMaybe;
+
   const now = DateTime.now();
 
   if (now < tripStart) {

--- a/src/common/DatePicker2/CalendarMonth.tsx
+++ b/src/common/DatePicker2/CalendarMonth.tsx
@@ -53,10 +53,6 @@ export function CalendarMonth({
     return yearMonth.with({ day: 1 });
   }, [yearMonth]);
   const dayOfWeekArray = useMemo(() => {
-    const formatterAbbr = new Intl.DateTimeFormat('en-US', {
-      weekday: 'short',
-    });
-    const formatterFull = new Intl.DateTimeFormat('en-US', { weekday: 'long' });
     return Array.from({ length: 7 })
       .fill(0)
       .map((_, i) => {
@@ -65,8 +61,8 @@ export function CalendarMonth({
           days: i - startOfMonth.dayOfWeek + 1,
         });
         return {
-          abbr: formatterAbbr.format(dateTime),
-          full: formatterFull.format(dateTime),
+          abbr: dateTime.toLocaleString('en-US', { weekday: 'short' }),
+          full: dateTime.toLocaleString('en-US', { weekday: 'long' }),
         };
       });
   }, [startOfMonth]);

--- a/src/common/DatePicker2/CalendarMonth.tsx
+++ b/src/common/DatePicker2/CalendarMonth.tsx
@@ -60,9 +60,9 @@ export function CalendarMonth({
     return Array.from({ length: 7 })
       .fill(0)
       .map((_, i) => {
-        // "Mon"-"Sun"
+        // "Mon"-"Sun" at calendar headers
         const dateTime = startOfMonth.add({
-          days: i - startOfMonth.dayOfWeek - 1,
+          days: i - startOfMonth.dayOfWeek + 1,
         });
         return {
           abbr: formatterAbbr.format(dateTime),
@@ -84,6 +84,7 @@ export function CalendarMonth({
 
   const focusDayButton = useCallback(
     (date: Temporal.PlainDate) => {
+      console.log('focusDayButton', date.toString());
       setIsDayButtonFocused(true);
       onFocusDay(date);
     },
@@ -311,13 +312,19 @@ function isDateInRange(
   start?: Temporal.PlainDate,
   end?: Temporal.PlainDate,
 ) {
-  // console.log('isDateInRange', { date, start, end });
   if (start != null && end != null) {
-    return date >= start && date <= end;
+    // date >= start && date <= end
+    const isDateOnOrAfterStart = Temporal.PlainDate.compare(date, start) >= 0;
+    const isDateOnOrBeforeEnd = Temporal.PlainDate.compare(date, end) <= 0;
+    return isDateOnOrAfterStart && isDateOnOrBeforeEnd;
   } else if (start != null) {
-    return date >= start;
+    // date >= start
+    const isDateOnOrAfterStart = Temporal.PlainDate.compare(date, start) >= 0;
+    return isDateOnOrAfterStart;
   } else if (end != null) {
-    return date <= end;
+    // date <= end
+    const isDateOnOrBeforeEnd = Temporal.PlainDate.compare(date, end) <= 0;
+    return isDateOnOrBeforeEnd;
   }
   return true;
 }
@@ -326,11 +333,19 @@ function getDateInRange(
   start?: Temporal.PlainDate,
   end?: Temporal.PlainDate,
 ) {
-  if (start != null && date < start) {
-    return start;
+  if (start != null) {
+    // i.e. date < start
+    const isDateBeforeStart = Temporal.PlainDate.compare(date, start) < 0;
+    if (isDateBeforeStart) {
+      return start;
+    }
   }
-  if (end != null && date > end) {
-    return end;
+  if (end != null) {
+    // i.e. date > end
+    const isDateAfterEnd = Temporal.PlainDate.compare(date, end) > 0;
+    if (isDateAfterEnd) {
+      return end;
+    }
   }
   return date;
 }

--- a/src/common/DatePicker2/CalendarMonth.tsx
+++ b/src/common/DatePicker2/CalendarMonth.tsx
@@ -136,11 +136,11 @@ export function CalendarMonth({
           break;
         case 'Home':
           // Move to the first day of the week (Monday: 1); dayOfWeek is 1-7 (Monday-Sunday)
-          date = focusedDate.subtract({ days: focusedDate.dayOfWeek + 1 });
+          date = focusedDate.subtract({ days: focusedDate.dayOfWeek - 1 });
           break;
         case 'End':
           // Move to the last day of the week (Sunday: 7); dayOfWeek is 1-7 (Monday-Sunday)
-          date = focusedDate.add({ days: 7 - focusedDate.dayOfWeek + 1 });
+          date = focusedDate.add({ days: 7 - focusedDate.dayOfWeek });
           break;
         case 'Enter':
         case ' ':

--- a/src/common/DatePicker2/CalendarMonth.tsx
+++ b/src/common/DatePicker2/CalendarMonth.tsx
@@ -1,19 +1,33 @@
 import { ArrowLeftIcon, ArrowRightIcon } from '@radix-ui/react-icons';
 import { Box, Button, Grid } from '@radix-ui/themes';
 import clsx from 'clsx';
-import { DateTime } from 'luxon';
 import { useCallback, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import s from './CalendarMonth.module.css';
 
+function formatMonthYear(date: Temporal.PlainDate) {
+  return date.toLocaleString('en-US', {
+    month: 'long',
+    year: 'numeric',
+  });
+}
+
+function formatDate(date: Temporal.PlainDate) {
+  return date.toLocaleString('en-US', {
+    month: 'long',
+    day: 'numeric',
+    year: 'numeric',
+  });
+}
+
 export interface CalendarMonthProps {
-  yearMonth: DateTime;
-  focusedDate: DateTime;
-  selectedDate?: DateTime;
-  onSelectDay: (date: DateTime) => void;
-  onFocusDay: (date: DateTime) => void;
-  onHoverDay: (date: DateTime) => void;
-  min?: DateTime;
-  max?: DateTime;
+  yearMonth: Temporal.PlainDate;
+  focusedDate: Temporal.PlainDate;
+  selectedDate?: Temporal.PlainDate;
+  onSelectDay: (date: Temporal.PlainDate) => void;
+  onFocusDay: (date: Temporal.PlainDate) => void;
+  onHoverDay: (date: Temporal.PlainDate) => void;
+  min?: Temporal.PlainDate;
+  max?: Temporal.PlainDate;
   disabled?: boolean;
   className?: string;
   // A11Y: Phase 2 - Live announcements for month navigation
@@ -35,21 +49,30 @@ export function CalendarMonth({
   className,
   onLiveAnnouncement,
 }: CalendarMonthProps) {
-  const startOfMonth = yearMonth.startOf('month');
+  const startOfMonth = useMemo(() => {
+    return yearMonth.with({ day: 1 });
+  }, [yearMonth]);
   const dayOfWeekArray = useMemo(() => {
+    const formatterAbbr = new Intl.DateTimeFormat('en-US', {
+      weekday: 'short',
+    });
+    const formatterFull = new Intl.DateTimeFormat('en-US', { weekday: 'long' });
     return Array.from({ length: 7 })
       .fill(0)
       .map((_, i) => {
-        const dateTime = startOfMonth.startOf('week').plus({ days: i });
+        // "Mon"-"Sun"
+        const dateTime = startOfMonth.add({
+          days: i - startOfMonth.dayOfWeek - 1,
+        });
         return {
-          abbr: dateTime.toFormat('ccc'),
-          full: dateTime.toFormat('cccc'),
+          abbr: formatterAbbr.format(dateTime),
+          full: formatterFull.format(dateTime),
         };
       });
   }, [startOfMonth]);
   const daysBeforeStartOfMonthArray = useMemo(() => {
-    return Array.from({ length: startOfMonth.weekday - 1 }).map((_, i) => i);
-  }, [startOfMonth.weekday]);
+    return Array.from({ length: startOfMonth.dayOfWeek - 1 }).map((_, i) => i);
+  }, [startOfMonth.dayOfWeek]);
   const daysInMonthArray = useMemo(() => {
     return Array.from({ length: startOfMonth.daysInMonth ?? 0 }).map(
       (_, i) => i,
@@ -60,7 +83,7 @@ export function CalendarMonth({
   const [isDayButtonFocused, setIsDayButtonFocused] = useState(true);
 
   const focusDayButton = useCallback(
-    (date: DateTime) => {
+    (date: Temporal.PlainDate) => {
       setIsDayButtonFocused(true);
       onFocusDay(date);
     },
@@ -77,7 +100,7 @@ export function CalendarMonth({
   useLayoutEffect(() => {
     if (isDayButtonFocused) {
       const dayButton = gridRef.current?.querySelector(
-        `button[data-date="${focusedDate.toISODate()}"]`,
+        `button[data-date="${focusedDate.toString()}"]`,
       );
       if (dayButton) {
         (dayButton as HTMLButtonElement).focus();
@@ -87,34 +110,36 @@ export function CalendarMonth({
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
-      let date: DateTime;
+      let date: Temporal.PlainDate;
 
       switch (e.key) {
         // Reference: https://github.com/WickyNilliams/cally/blob/38e6a7bc7c53e29c427f5de028b8544e2bff9a9d/src/calendar-month/useCalendarMonth.ts#L74-L101
         // MIT License (c) WickyNilliams
         case 'ArrowRight':
-          date = focusedDate.plus({ days: 1 });
+          date = focusedDate.add({ days: 1 });
           break;
         case 'ArrowLeft':
-          date = focusedDate.plus({ days: -1 });
+          date = focusedDate.add({ days: -1 });
           break;
         case 'ArrowDown':
-          date = focusedDate.plus({ days: 7 });
+          date = focusedDate.add({ days: 7 });
           break;
         case 'ArrowUp':
-          date = focusedDate.plus({ days: -7 });
+          date = focusedDate.add({ days: -7 });
           break;
         case 'PageUp':
-          date = focusedDate.plus(e.shiftKey ? { years: -1 } : { months: -1 });
+          date = focusedDate.add(e.shiftKey ? { years: -1 } : { months: -1 });
           break;
         case 'PageDown':
-          date = focusedDate.plus(e.shiftKey ? { years: 1 } : { months: 1 });
+          date = focusedDate.add(e.shiftKey ? { years: 1 } : { months: 1 });
           break;
         case 'Home':
-          date = focusedDate.startOf('week');
+          // Move to the first day of the week (Monday: 1); dayOfWeek is 1-7 (Monday-Sunday)
+          date = focusedDate.subtract({ days: focusedDate.dayOfWeek + 1 });
           break;
         case 'End':
-          date = focusedDate.endOf('week');
+          // Move to the last day of the week (Sunday: 7); dayOfWeek is 1-7 (Monday-Sunday)
+          date = focusedDate.add({ days: 7 - focusedDate.dayOfWeek + 1 });
           break;
         case 'Enter':
         case ' ':
@@ -139,9 +164,8 @@ export function CalendarMonth({
     (e: React.MouseEvent) => {
       const target = e.target as HTMLElement;
       const dateStr = target.getAttribute('data-date');
-      const dateZone = target.getAttribute('data-timezone');
       if (dateStr) {
-        const date = DateTime.fromISO(dateStr, { zone: dateZone ?? undefined });
+        const date = Temporal.PlainDate.from(dateStr);
         if (!isDateInRange(date, min, max)) {
           return;
         }
@@ -156,9 +180,8 @@ export function CalendarMonth({
     (e: React.MouseEvent) => {
       const target = e.target as HTMLElement;
       const dateStr = target.getAttribute('data-date');
-      const dateZone = target.getAttribute('data-timezone');
       if (dateStr) {
-        const date = DateTime.fromISO(dateStr, { zone: dateZone ?? undefined });
+        const date = Temporal.PlainDate.from(dateStr);
         if (!isDateInRange(date, min, max)) {
           return;
         }
@@ -170,26 +193,35 @@ export function CalendarMonth({
 
   const handlePreviousMonth = useCallback(() => {
     const prevMonth = getDateInRange(
-      startOfMonth.plus({ months: -1 }),
+      startOfMonth.add({ months: -1 }),
       min,
       max,
     );
     onFocusDay(prevMonth);
-    onLiveAnnouncement?.(prevMonth.toFormat('MMMM yyyy'));
+    onLiveAnnouncement?.(formatMonthYear(prevMonth));
   }, [startOfMonth, onFocusDay, min, max, onLiveAnnouncement]);
 
   const handleNextMonth = useCallback(() => {
-    const nextMonth = getDateInRange(
-      startOfMonth.plus({ months: 1 }),
-      min,
-      max,
-    );
+    const nextMonth = getDateInRange(startOfMonth.add({ months: 1 }), min, max);
     onFocusDay(nextMonth);
-    onLiveAnnouncement?.(nextMonth.toFormat('MMMM yyyy'));
+    onLiveAnnouncement?.(formatMonthYear(nextMonth));
   }, [startOfMonth, onFocusDay, min, max, onLiveAnnouncement]);
 
-  const isPrevMonthDisabled = min && startOfMonth <= min.startOf('month');
-  const isNextMonthDisabled = max && startOfMonth >= max.startOf('month');
+  const isPrevMonthDisabled = useMemo(() => {
+    if (!min) {
+      return false;
+    }
+    const minStartofMonth = min.with({ day: 1 });
+    // Temporal.PlainDate.compare: Returns -1 if date1 comes before date2, 0 if they are the same, and 1 if date1 comes after date2
+    return Temporal.PlainDate.compare(startOfMonth, minStartofMonth) <= 0;
+  }, [min, startOfMonth]);
+  const isNextMonthDisabled = useMemo(() => {
+    if (!max) {
+      return false;
+    }
+    const maxStartofMonth = max.with({ day: 1 });
+    return Temporal.PlainDate.compare(startOfMonth, maxStartofMonth) >= 0;
+  }, [max, startOfMonth]);
 
   return (
     <Grid
@@ -199,7 +231,7 @@ export function CalendarMonth({
       ref={gridRef}
       className={clsx(s.calendarMonth, className)}
       role="grid"
-      aria-label={`Calendar for ${startOfMonth.toFormat('MMMM yyyy')}`}
+      aria-label={`Calendar for ${startOfMonth}`}
     >
       <Button
         variant="surface"
@@ -212,7 +244,7 @@ export function CalendarMonth({
         <ArrowLeftIcon aria-hidden="true" />
       </Button>
       <Box gridColumnStart="2" gridColumnEnd="7" className={s.monthLabel}>
-        {startOfMonth.toFormat('MMMM yyyy')}
+        {formatMonthYear(startOfMonth)}
       </Box>
       <Button
         variant="surface"
@@ -238,14 +270,12 @@ export function CalendarMonth({
         <Box key={i} />
       ))}
       {daysInMonthArray.map((i) => {
-        const date = startOfMonth.set({ day: i + 1 });
-        const isFocused = date.hasSame(focusedDate, 'day');
-        const isSelected = selectedDate
-          ? date.hasSame(selectedDate, 'day')
-          : false;
+        const date = startOfMonth.with({ day: i + 1 });
+        const isFocused = date.equals(focusedDate);
+        const isSelected = selectedDate ? date.equals(selectedDate) : false;
         const isDisabled = disabled || !isDateInRange(date, min, max);
         // A11Y: Mark today's date for screen readers
-        const isToday = date.hasSame(DateTime.now(), 'day');
+        const isToday = date.equals(Temporal.Now.plainDateISO());
 
         return (
           // biome-ignore lint/a11y/useSemanticElements: this is a button on a grid
@@ -253,23 +283,22 @@ export function CalendarMonth({
             type="button"
             role="gridcell"
             disabled={isDisabled}
-            key={date.toISODate()}
+            key={date.toString()}
             onKeyDown={handleKeyDown}
             onFocus={handleFocus}
             onBlur={handleBlur}
             onClick={handleClick}
             onMouseOver={handleMouseOver}
             tabIndex={isFocused ? 0 : -1}
-            data-date={date.toISODate()}
-            data-timezone={date.zoneName}
+            data-date={date.toString()}
             className={clsx(s.dayButton, {
               [s.dayButtonSelected]: isSelected,
             })}
-            aria-label={date.toFormat('cccc, MMMM d, yyyy')}
+            aria-label={formatDate(date)}
             aria-selected={isSelected}
             aria-current={isToday ? 'date' : undefined}
           >
-            {date.toFormat('d')}
+            {date.day}
           </button>
         );
       })}
@@ -277,7 +306,11 @@ export function CalendarMonth({
   );
 }
 
-function isDateInRange(date: DateTime, start?: DateTime, end?: DateTime) {
+function isDateInRange(
+  date: Temporal.PlainDate,
+  start?: Temporal.PlainDate,
+  end?: Temporal.PlainDate,
+) {
   // console.log('isDateInRange', { date, start, end });
   if (start != null && end != null) {
     return date >= start && date <= end;
@@ -288,7 +321,11 @@ function isDateInRange(date: DateTime, start?: DateTime, end?: DateTime) {
   }
   return true;
 }
-function getDateInRange(date: DateTime, start?: DateTime, end?: DateTime) {
+function getDateInRange(
+  date: Temporal.PlainDate,
+  start?: Temporal.PlainDate,
+  end?: Temporal.PlainDate,
+) {
   if (start != null && date < start) {
     return start;
   }

--- a/src/common/DatePicker2/DateTimePicker.tsx
+++ b/src/common/DatePicker2/DateTimePicker.tsx
@@ -1,3 +1,4 @@
+/** biome-ignore-all lint/correctness/useHookAtTopLevel: Biome bug:https://github.com/biomejs/biome/issues/9195 */
 import {
   ChevronDownIcon,
   ChevronUpIcon,
@@ -13,10 +14,7 @@ import {
 } from 'react';
 import { CalendarMonth } from './CalendarMonth';
 import s from './DateTimePicker.module.css';
-import {
-  DateTimePickerMode,
-  type DateTimePickerModeType,
-} from './DateTimePickerMode';
+import { DateTimePickerMode } from './DateTimePickerMode';
 import { LiveRegion } from './LiveRegion';
 import { TimeSelector } from './TimeSelector';
 import type {
@@ -25,10 +23,39 @@ import type {
   DatePickerState,
 } from './types';
 
-function datePickerReducer<TMode extends DateTimePickerModeType>(
-  state: DatePickerState<TMode>,
-  action: DatePickerAction<TMode>,
-): DatePickerState<TMode> {
+function formatLiveMessage(date: Temporal.PlainDate | Temporal.PlainDateTime) {
+  return date.toLocaleString('en-US', {
+    weekday: 'long',
+    month: 'long',
+    day: 'numeric',
+    year: 'numeric',
+  });
+}
+function formatDate(plainDate: Temporal.PlainDate) {
+  // TODO: customize format to match Luxon's "d LLLL yyyy"
+  return plainDate.toLocaleString('en-US', {
+    weekday: 'long',
+    month: 'long',
+    day: 'numeric',
+    year: 'numeric',
+  });
+}
+function formatDateTime(plainDateTime: Temporal.PlainDateTime) {
+  // TODO: customize format to match Luxon's "d LLLL yyyy HH:mm"
+  return plainDateTime.toLocaleString('en-US', {
+    weekday: 'long',
+    month: 'long',
+    day: 'numeric',
+    year: 'numeric',
+    hour: 'numeric',
+    minute: 'numeric',
+  });
+}
+
+function datePickerReducer(
+  state: DatePickerState,
+  action: DatePickerAction,
+): DatePickerState {
   // console.log(
   //   '!! datePickerReducer',
   //   action,
@@ -45,45 +72,24 @@ function datePickerReducer<TMode extends DateTimePickerModeType>(
       return { ...state, focusedMinute: action.minute };
     }
     case 'setSelectedDate': {
-      const selectedDateTime = action.date?.set({
-        hour: state.selectedHour ?? 0,
-        minute: state.selectedMinute ?? 0,
-        second: 0,
-        millisecond: 0,
-      });
       return {
         ...state,
         selectedDate: action.date,
         focusedDate: action.date,
-        selectedDateTime,
       };
     }
     case 'setSelectedHour': {
-      const selectedDateTime = state.selectedDateTime?.set({
-        hour: action.hour,
-        minute: state.selectedMinute ?? 0,
-        second: 0,
-        millisecond: 0,
-      });
       return {
         ...state,
         selectedHour: action.hour,
         focusedHour: action.hour,
-        selectedDateTime,
       };
     }
     case 'setSelectedMinute': {
-      const selectedDateTime = state.selectedDateTime?.set({
-        hour: state.selectedHour ?? 0,
-        minute: action.minute,
-        second: 0,
-        millisecond: 0,
-      });
       return {
         ...state,
         selectedMinute: action.minute,
         focusedMinute: action.minute,
-        selectedDateTime,
       };
     }
     case 'setHoveredDate': {
@@ -111,35 +117,55 @@ function datePickerReducer<TMode extends DateTimePickerModeType>(
   }
 }
 
-function DateTimePickerInner<TMode extends DateTimePickerModeType>(
-  props: DatePickerProps<TMode>,
+function DateTimePickerInner(
+  props: DatePickerProps,
   ref: React.ForwardedRef<HTMLButtonElement>,
 ) {
   // TODO: change all internal state to temporal
   // TODO: then change usage to read from temporal instead of luxon DateTime
-  const [state, dispatch] = useReducer(datePickerReducer<TMode>, {
-    isOpen: false,
-    // We need at least focusedDate to decide which month to show, else we can't show anything
-    focusedDate:
-      props.value ??
-      (props.mode === DateTimePickerMode.Date
-        ? Temporal.Now.plainDateISO()
-        : Temporal.Now.plainDateTimeISO()),
-    selectedDate: props.value,
-    selectedDateTime: props.value,
-    hoveredDate: undefined,
-    focusedHour: props.mode === 'datetime' ? props.value?.hour : undefined,
-    focusedMinute: props.mode === 'datetime' ? props.value?.minute : undefined,
-    selectedHour: props.mode === 'datetime' ? props.value?.hour : undefined,
-    selectedMinute: props.mode === 'datetime' ? props.value?.minute : undefined,
-    min: props.min,
-    max: props.max,
-  } as DatePickerState<TMode>);
+  const [state, dispatch] = useReducer(datePickerReducer, props, (props) => {
+    const mode = props.mode;
+    const ret =
+      mode === DateTimePickerMode.DateTime
+        ? {
+            focusedHour: (props.value as Temporal.PlainDateTime | undefined)
+              ?.hour,
+            focusedMinute: (props.value as Temporal.PlainDateTime | undefined)
+              ?.minute,
+            selectedHour: (props.value as Temporal.PlainDateTime | undefined)
+              ?.hour,
+            selectedMinute: (props.value as Temporal.PlainDateTime | undefined)
+              ?.minute,
+          }
+        : {
+            focusedHour: undefined,
+            focusedMinute: undefined,
+            selectedHour: undefined,
+            selectedMinute: undefined,
+          };
+    return {
+      isOpen: false,
+      // We need at least focusedDate to decide which month to show, else we can't show anything
+      focusedDate:
+        props.value ??
+        (props.mode === DateTimePickerMode.Date
+          ? Temporal.Now.plainDateISO()
+          : Temporal.Now.plainDateTimeISO()),
+      selectedDate: props.value,
+      hoveredDate: undefined,
+      ...ret,
+      min: props.min,
+      max: props.max,
+    };
+  });
 
   // Handle props.value change from outside
   useEffect(() => {
     if (props.value) {
-      dispatch({ type: 'setSelectedDate', date: props.value.startOf('day') });
+      dispatch({
+        type: 'setSelectedDate',
+        date: props.value,
+      });
       if (props.mode === DateTimePickerMode.DateTime) {
         dispatch({ type: 'setSelectedHour', hour: props.value.hour });
         dispatch({ type: 'setSelectedMinute', minute: props.value.minute });
@@ -150,14 +176,14 @@ function DateTimePickerInner<TMode extends DateTimePickerModeType>(
   }, [props.value, props.mode]);
 
   const [liveMessage, setLiveMessage] = useState('');
-  const handleFocusDay = useCallback((date: DateTime) => {
+  const handleFocusDay = useCallback((date: Temporal.PlainDate) => {
     dispatch({ type: 'setFocusedDate', date });
-    setLiveMessage(`${date.toFormat('cccc, MMMM d, yyyy')}`);
+    setLiveMessage(`${formatLiveMessage(date)}`);
   }, []);
 
-  const handleSelectDay = useCallback((date: DateTime) => {
+  const handleSelectDay = useCallback((date: Temporal.PlainDate) => {
     dispatch({ type: 'setSelectedDate', date });
-    setLiveMessage(`Selected ${date.toFormat('cccc, MMMM d, yyyy')}`);
+    setLiveMessage(`Selected ${formatLiveMessage(date)}`);
   }, []);
 
   const handleSelectHour = useCallback((hour: number) => {
@@ -176,7 +202,7 @@ function DateTimePickerInner<TMode extends DateTimePickerModeType>(
     dispatch({ type: 'setFocusedMinute', minute });
   }, []);
 
-  const handleHoverDay = useCallback((date: DateTime) => {
+  const handleHoverDay = useCallback((date: Temporal.PlainDate) => {
     dispatch({ type: 'setHoveredDate', date });
   }, []);
   const handleClearButtonClicked = useCallback(() => {
@@ -191,11 +217,19 @@ function DateTimePickerInner<TMode extends DateTimePickerModeType>(
     if (originalDate) {
       dispatch({
         type: 'setSelectedDate',
-        date: originalDate.startOf('day'),
+        date: originalDate,
       });
       if (props.mode === DateTimePickerMode.DateTime) {
-        dispatch({ type: 'setSelectedHour', hour: originalDate.hour });
-        dispatch({ type: 'setSelectedMinute', minute: originalDate.minute });
+        // Because props.mode === 'datetime', originalDate must be Temporal.PlainDateTime
+        const originalDateTime = originalDate as Temporal.PlainDateTime;
+        dispatch({
+          type: 'setSelectedHour',
+          hour: originalDateTime.hour,
+        });
+        dispatch({
+          type: 'setSelectedMinute',
+          minute: originalDateTime.minute,
+        });
       }
     }
 
@@ -241,7 +275,7 @@ function DateTimePickerInner<TMode extends DateTimePickerModeType>(
     }
   }, []);
 
-  const formattedValue = props.value?.toISO() || '';
+  const formattedValue = props.value?.toString() || '';
 
   return (
     <>
@@ -277,15 +311,14 @@ function DateTimePickerInner<TMode extends DateTimePickerModeType>(
               aria-invalid={props['aria-invalid']}
               disabled={props.disabled}
             >
-              {props.value?.toFormat(
-                props.mode === DateTimePickerMode.DateTime
-                  ? 'd LLLL yyyy HH:mm'
-                  : 'd LLLL yyyy',
-              ) ??
-                (props.placeholder ||
+              {props.value
+                ? props.mode === DateTimePickerMode.DateTime
+                  ? formatDateTime(props.value as Temporal.PlainDateTime)
+                  : formatDate(props.value as Temporal.PlainDate)
+                : props.placeholder ||
                   (props.mode === DateTimePickerMode.DateTime
                     ? 'Select date & time'
-                    : 'Select date'))}
+                    : 'Select date')}
               {state.isOpen ? (
                 <ChevronUpIcon aria-hidden="true" />
               ) : (
@@ -317,9 +350,21 @@ function DateTimePickerInner<TMode extends DateTimePickerModeType>(
           >
             <div className={s.calendarAndTime}>
               <CalendarMonth
-                yearMonth={state.focusedDate}
-                focusedDate={state.focusedDate}
-                selectedDate={state.selectedDate}
+                yearMonth={
+                  state.focusedDate instanceof Temporal.PlainDateTime
+                    ? state.focusedDate.toPlainDate()
+                    : state.focusedDate
+                }
+                focusedDate={
+                  state.focusedDate instanceof Temporal.PlainDateTime
+                    ? state.focusedDate.toPlainDate()
+                    : state.focusedDate
+                }
+                selectedDate={
+                  state.selectedDate instanceof Temporal.PlainDateTime
+                    ? state.selectedDate.toPlainDate()
+                    : state.selectedDate
+                }
                 onFocusDay={handleFocusDay}
                 onSelectDay={handleSelectDay}
                 onHoverDay={handleHoverDay}
@@ -368,10 +413,4 @@ function DateTimePickerInner<TMode extends DateTimePickerModeType>(
   );
 }
 
-export const DateTimePicker = forwardRef(DateTimePickerInner) as <
-  mode extends DateTimePickerModeType,
->(
-  props: DatePickerProps<mode> & {
-    ref?: React.ForwardedRef<HTMLButtonElement>;
-  },
-) => ReturnType<typeof DateTimePickerInner>;
+export const DateTimePicker = forwardRef(DateTimePickerInner);

--- a/src/common/DatePicker2/DateTimePicker.tsx
+++ b/src/common/DatePicker2/DateTimePicker.tsx
@@ -121,6 +121,7 @@ function DateTimePickerInner(
   props: DatePickerProps,
   ref: React.ForwardedRef<HTMLButtonElement>,
 ) {
+  // TODO: Need to have guard where mode === 'datetime' then value passed must be Temporal.PlainDateTime and NOT Temporal.PlainDate, and vice versa. Otherwise, it will cause runtime error when trying to access hour/minute of Temporal.PlainDate which doesn't have hour/minute; and vice versa, if mode === 'date' then value passed must be Temporal.PlainDate and NOT Temporal.PlainDateTime. Otherwise, it will cause runtime error when trying to access hour/minute of Temporal.PlainDate which doesn't have hour/minute.
   // TODO: change all internal state to temporal
   // TODO: then change usage to read from temporal instead of luxon DateTime
   const [state, dispatch] = useReducer(datePickerReducer, props, (props) => {
@@ -143,15 +144,16 @@ function DateTimePickerInner(
             selectedHour: undefined,
             selectedMinute: undefined,
           };
+
+    const valueDate =
+      props.value instanceof Temporal.PlainDateTime
+        ? props.value.toPlainDate()
+        : (props.value as Temporal.PlainDate | undefined);
     return {
       isOpen: false,
       // We need at least focusedDate to decide which month to show, else we can't show anything
-      focusedDate:
-        props.value ??
-        (props.mode === DateTimePickerMode.Date
-          ? Temporal.Now.plainDateISO()
-          : Temporal.Now.plainDateTimeISO()),
-      selectedDate: props.value,
+      focusedDate: valueDate ?? Temporal.Now.plainDateISO(),
+      selectedDate: valueDate,
       hoveredDate: undefined,
       ...ret,
       min: props.min,
@@ -162,13 +164,20 @@ function DateTimePickerInner(
   // Handle props.value change from outside
   useEffect(() => {
     if (props.value) {
-      dispatch({
-        type: 'setSelectedDate',
-        date: props.value,
-      });
       if (props.mode === DateTimePickerMode.DateTime) {
-        dispatch({ type: 'setSelectedHour', hour: props.value.hour });
-        dispatch({ type: 'setSelectedMinute', minute: props.value.minute });
+        const dateTime = props.value as Temporal.PlainDateTime;
+        dispatch({
+          type: 'setSelectedDate',
+          date: dateTime.toPlainDate(),
+        });
+        dispatch({ type: 'setSelectedHour', hour: dateTime.hour });
+        dispatch({ type: 'setSelectedMinute', minute: dateTime.minute });
+      } else {
+        const date = props.value as Temporal.PlainDate;
+        dispatch({
+          type: 'setSelectedDate',
+          date: date,
+        });
       }
     } else {
       dispatch({ type: 'clear' });
@@ -213,22 +222,28 @@ function DateTimePickerInner(
   }, [props.onChange, props.clearable]);
   const handleCancelButtonClicked = useCallback(() => {
     // Change selected to previous value (original value in props)
-    const originalDate = props.value;
-    if (originalDate) {
-      dispatch({
-        type: 'setSelectedDate',
-        date: originalDate,
-      });
+    const value = props.value;
+    if (value) {
       if (props.mode === DateTimePickerMode.DateTime) {
         // Because props.mode === 'datetime', originalDate must be Temporal.PlainDateTime
-        const originalDateTime = originalDate as Temporal.PlainDateTime;
+        const dateTime = value as Temporal.PlainDateTime;
+        dispatch({
+          type: 'setSelectedDate',
+          date: dateTime.toPlainDate(),
+        });
         dispatch({
           type: 'setSelectedHour',
-          hour: originalDateTime.hour,
+          hour: dateTime.hour,
         });
         dispatch({
           type: 'setSelectedMinute',
-          minute: originalDateTime.minute,
+          minute: dateTime.minute,
+        });
+      } else {
+        const date = value as Temporal.PlainDate;
+        dispatch({
+          type: 'setSelectedDate',
+          date,
         });
       }
     }
@@ -237,18 +252,19 @@ function DateTimePickerInner(
   }, [props.value, props.mode]);
 
   const handleSubmit = useCallback(() => {
-    if (props.mode === DateTimePickerMode.Date) {
-      if (state.selectedDate) {
-        props.onChange?.(state.selectedDate);
+    if (state.selectedDate && props.onChange) {
+      if (props.mode === DateTimePickerMode.DateTime) {
+        props.onChange(
+          Temporal.PlainDateTime.from(state.selectedDate).withPlainTime({
+            hour: state.selectedHour ?? 0,
+            minute: state.selectedMinute ?? 0,
+            second: 0,
+            millisecond: 0,
+          }),
+        );
+      } else {
+        props.onChange(state.selectedDate);
       }
-    } else if (state.selectedDate) {
-      const date = state.selectedDate.set({
-        hour: state.selectedHour ?? 0,
-        minute: state.selectedMinute ?? 0,
-        second: 0,
-        millisecond: 0,
-      });
-      props.onChange?.(date);
     }
     dispatch({ type: 'close' });
   }, [
@@ -350,21 +366,9 @@ function DateTimePickerInner(
           >
             <div className={s.calendarAndTime}>
               <CalendarMonth
-                yearMonth={
-                  state.focusedDate instanceof Temporal.PlainDateTime
-                    ? state.focusedDate.toPlainDate()
-                    : state.focusedDate
-                }
-                focusedDate={
-                  state.focusedDate instanceof Temporal.PlainDateTime
-                    ? state.focusedDate.toPlainDate()
-                    : state.focusedDate
-                }
-                selectedDate={
-                  state.selectedDate instanceof Temporal.PlainDateTime
-                    ? state.selectedDate.toPlainDate()
-                    : state.selectedDate
-                }
+                yearMonth={state.focusedDate}
+                focusedDate={state.focusedDate}
+                selectedDate={state.selectedDate}
                 onFocusDay={handleFocusDay}
                 onSelectDay={handleSelectDay}
                 onHoverDay={handleHoverDay}

--- a/src/common/DatePicker2/DateTimePicker.tsx
+++ b/src/common/DatePicker2/DateTimePicker.tsx
@@ -22,35 +22,7 @@ import type {
   DatePickerProps,
   DatePickerState,
 } from './types';
-
-function formatLiveMessage(date: Temporal.PlainDate | Temporal.PlainDateTime) {
-  return date.toLocaleString('en-US', {
-    weekday: 'long',
-    month: 'long',
-    day: 'numeric',
-    year: 'numeric',
-  });
-}
-function formatDate(plainDate: Temporal.PlainDate) {
-  // TODO: customize format to match Luxon's "d LLLL yyyy"
-  return plainDate.toLocaleString('en-US', {
-    weekday: 'long',
-    month: 'long',
-    day: 'numeric',
-    year: 'numeric',
-  });
-}
-function formatDateTime(plainDateTime: Temporal.PlainDateTime) {
-  // TODO: customize format to match Luxon's "d LLLL yyyy HH:mm"
-  return plainDateTime.toLocaleString('en-US', {
-    weekday: 'long',
-    month: 'long',
-    day: 'numeric',
-    year: 'numeric',
-    hour: 'numeric',
-    minute: 'numeric',
-  });
-}
+import { toFormat } from '../dateTime/temporalFormatter';
 
 function datePickerReducer(
   state: DatePickerState,
@@ -187,12 +159,12 @@ function DateTimePickerInner(
   const [liveMessage, setLiveMessage] = useState('');
   const handleFocusDay = useCallback((date: Temporal.PlainDate) => {
     dispatch({ type: 'setFocusedDate', date });
-    setLiveMessage(`${formatLiveMessage(date)}`);
+    setLiveMessage(`${toFormat('cccc, MMMM d, yyyy', date)}`);
   }, []);
 
   const handleSelectDay = useCallback((date: Temporal.PlainDate) => {
     dispatch({ type: 'setSelectedDate', date });
-    setLiveMessage(`Selected ${formatLiveMessage(date)}`);
+    setLiveMessage(`Selected ${toFormat('cccc, MMMM d, yyyy', date)}`);
   }, []);
 
   const handleSelectHour = useCallback((hour: number) => {
@@ -329,8 +301,11 @@ function DateTimePickerInner(
             >
               {props.value
                 ? props.mode === DateTimePickerMode.DateTime
-                  ? formatDateTime(props.value as Temporal.PlainDateTime)
-                  : formatDate(props.value as Temporal.PlainDate)
+                  ? toFormat(
+                      'd LLLL yyyy HH:mm',
+                      props.value as Temporal.PlainDateTime,
+                    )
+                  : toFormat('d LLLL yyyy', props.value as Temporal.PlainDate)
                 : props.placeholder ||
                   (props.mode === DateTimePickerMode.DateTime
                     ? 'Select date & time'

--- a/src/common/DatePicker2/DateTimePicker.tsx
+++ b/src/common/DatePicker2/DateTimePicker.tsx
@@ -12,6 +12,7 @@ import {
   useReducer,
   useState,
 } from 'react';
+import { toFormat } from '../dateTime/temporalFormatter';
 import { CalendarMonth } from './CalendarMonth';
 import s from './DateTimePicker.module.css';
 import { DateTimePickerMode } from './DateTimePickerMode';
@@ -22,7 +23,6 @@ import type {
   DatePickerProps,
   DatePickerState,
 } from './types';
-import { toFormat } from '../dateTime/temporalFormatter';
 
 function datePickerReducer(
   state: DatePickerState,

--- a/src/common/DatePicker2/DateTimePicker.tsx
+++ b/src/common/DatePicker2/DateTimePicker.tsx
@@ -4,7 +4,6 @@ import {
   Cross1Icon,
 } from '@radix-ui/react-icons';
 import { Button, Popover } from '@radix-ui/themes';
-import { DateTime } from 'luxon';
 import {
   forwardRef,
   useCallback,
@@ -14,7 +13,10 @@ import {
 } from 'react';
 import { CalendarMonth } from './CalendarMonth';
 import s from './DateTimePicker.module.css';
-import { DateTimePickerMode } from './DateTimePickerMode';
+import {
+  DateTimePickerMode,
+  type DateTimePickerModeType,
+} from './DateTimePickerMode';
 import { LiveRegion } from './LiveRegion';
 import { TimeSelector } from './TimeSelector';
 import type {
@@ -23,10 +25,10 @@ import type {
   DatePickerState,
 } from './types';
 
-function datePickerReducer(
-  state: DatePickerState,
-  action: DatePickerAction,
-): DatePickerState {
+function datePickerReducer<TMode extends DateTimePickerModeType>(
+  state: DatePickerState<TMode>,
+  action: DatePickerAction<TMode>,
+): DatePickerState<TMode> {
   // console.log(
   //   '!! datePickerReducer',
   //   action,
@@ -109,252 +111,267 @@ function datePickerReducer(
   }
 }
 
-export const DateTimePicker = forwardRef<HTMLButtonElement, DatePickerProps>(
-  (props, ref) => {
-    const [state, dispatch] = useReducer(datePickerReducer, {
-      isOpen: false,
-      // We need at least focusedDate to decide which month to show, else we can't show anything
-      focusedDate: props.value?.startOf('day') ?? DateTime.now().startOf('day'),
-      selectedDate: props.value?.startOf('day') ?? undefined,
-      selectedDateTime: props.value,
-      hoveredDate: undefined,
-      focusedHour: props.value?.hour,
-      focusedMinute: props.value?.minute,
-      selectedHour: props.value?.hour,
-      selectedMinute: props.value?.minute,
-      min: props.min?.startOf('day') ?? undefined,
-      max: props.max?.startOf('day') ?? undefined,
-    });
+function DateTimePickerInner<TMode extends DateTimePickerModeType>(
+  props: DatePickerProps<TMode>,
+  ref: React.ForwardedRef<HTMLButtonElement>,
+) {
+  // TODO: change all internal state to temporal
+  // TODO: then change usage to read from temporal instead of luxon DateTime
+  const [state, dispatch] = useReducer(datePickerReducer<TMode>, {
+    isOpen: false,
+    // We need at least focusedDate to decide which month to show, else we can't show anything
+    focusedDate:
+      props.value ??
+      (props.mode === DateTimePickerMode.Date
+        ? Temporal.Now.plainDateISO()
+        : Temporal.Now.plainDateTimeISO()),
+    selectedDate: props.value,
+    selectedDateTime: props.value,
+    hoveredDate: undefined,
+    focusedHour: props.mode === 'datetime' ? props.value?.hour : undefined,
+    focusedMinute: props.mode === 'datetime' ? props.value?.minute : undefined,
+    selectedHour: props.mode === 'datetime' ? props.value?.hour : undefined,
+    selectedMinute: props.mode === 'datetime' ? props.value?.minute : undefined,
+    min: props.min,
+    max: props.max,
+  } as DatePickerState<TMode>);
 
-    // Handle props.value change from outside
-    useEffect(() => {
-      if (props.value) {
-        dispatch({ type: 'setSelectedDate', date: props.value.startOf('day') });
-        if (props.mode === DateTimePickerMode.DateTime) {
-          dispatch({ type: 'setSelectedHour', hour: props.value.hour });
-          dispatch({ type: 'setSelectedMinute', minute: props.value.minute });
-        }
-      } else {
-        dispatch({ type: 'clear' });
+  // Handle props.value change from outside
+  useEffect(() => {
+    if (props.value) {
+      dispatch({ type: 'setSelectedDate', date: props.value.startOf('day') });
+      if (props.mode === DateTimePickerMode.DateTime) {
+        dispatch({ type: 'setSelectedHour', hour: props.value.hour });
+        dispatch({ type: 'setSelectedMinute', minute: props.value.minute });
       }
-    }, [props.value, props.mode]);
-
-    const [liveMessage, setLiveMessage] = useState('');
-    const handleFocusDay = useCallback((date: DateTime) => {
-      dispatch({ type: 'setFocusedDate', date });
-      setLiveMessage(`${date.toFormat('cccc, MMMM d, yyyy')}`);
-    }, []);
-
-    const handleSelectDay = useCallback((date: DateTime) => {
-      dispatch({ type: 'setSelectedDate', date });
-      setLiveMessage(`Selected ${date.toFormat('cccc, MMMM d, yyyy')}`);
-    }, []);
-
-    const handleSelectHour = useCallback((hour: number) => {
-      dispatch({ type: 'setSelectedHour', hour });
-      setLiveMessage(`Hour ${hour}`);
-    }, []);
-
-    const handleSelectMinute = useCallback((minute: number) => {
-      dispatch({ type: 'setSelectedMinute', minute });
-      setLiveMessage(`Minute ${minute}`);
-    }, []);
-    const handleFocusHour = useCallback((hour: number) => {
-      dispatch({ type: 'setFocusedHour', hour });
-    }, []);
-    const handleFocusMinute = useCallback((minute: number) => {
-      dispatch({ type: 'setFocusedMinute', minute });
-    }, []);
-
-    const handleHoverDay = useCallback((date: DateTime) => {
-      dispatch({ type: 'setHoveredDate', date });
-    }, []);
-    const handleClearButtonClicked = useCallback(() => {
-      if (!props.clearable) return;
+    } else {
       dispatch({ type: 'clear' });
-      dispatch({ type: 'close' });
-      props.onChange(undefined);
-    }, [props.onChange, props.clearable]);
-    const handleCancelButtonClicked = useCallback(() => {
-      // Change selected to previous value (original value in props)
-      const originalDate = props.value;
-      if (originalDate) {
-        dispatch({
-          type: 'setSelectedDate',
-          date: originalDate.startOf('day'),
-        });
-        if (props.mode === DateTimePickerMode.DateTime) {
-          dispatch({ type: 'setSelectedHour', hour: originalDate.hour });
-          dispatch({ type: 'setSelectedMinute', minute: originalDate.minute });
-        }
+    }
+  }, [props.value, props.mode]);
+
+  const [liveMessage, setLiveMessage] = useState('');
+  const handleFocusDay = useCallback((date: DateTime) => {
+    dispatch({ type: 'setFocusedDate', date });
+    setLiveMessage(`${date.toFormat('cccc, MMMM d, yyyy')}`);
+  }, []);
+
+  const handleSelectDay = useCallback((date: DateTime) => {
+    dispatch({ type: 'setSelectedDate', date });
+    setLiveMessage(`Selected ${date.toFormat('cccc, MMMM d, yyyy')}`);
+  }, []);
+
+  const handleSelectHour = useCallback((hour: number) => {
+    dispatch({ type: 'setSelectedHour', hour });
+    setLiveMessage(`Hour ${hour}`);
+  }, []);
+
+  const handleSelectMinute = useCallback((minute: number) => {
+    dispatch({ type: 'setSelectedMinute', minute });
+    setLiveMessage(`Minute ${minute}`);
+  }, []);
+  const handleFocusHour = useCallback((hour: number) => {
+    dispatch({ type: 'setFocusedHour', hour });
+  }, []);
+  const handleFocusMinute = useCallback((minute: number) => {
+    dispatch({ type: 'setFocusedMinute', minute });
+  }, []);
+
+  const handleHoverDay = useCallback((date: DateTime) => {
+    dispatch({ type: 'setHoveredDate', date });
+  }, []);
+  const handleClearButtonClicked = useCallback(() => {
+    if (!props.clearable) return;
+    dispatch({ type: 'clear' });
+    dispatch({ type: 'close' });
+    props.onChange(undefined);
+  }, [props.onChange, props.clearable]);
+  const handleCancelButtonClicked = useCallback(() => {
+    // Change selected to previous value (original value in props)
+    const originalDate = props.value;
+    if (originalDate) {
+      dispatch({
+        type: 'setSelectedDate',
+        date: originalDate.startOf('day'),
+      });
+      if (props.mode === DateTimePickerMode.DateTime) {
+        dispatch({ type: 'setSelectedHour', hour: originalDate.hour });
+        dispatch({ type: 'setSelectedMinute', minute: originalDate.minute });
       }
+    }
 
-      dispatch({ type: 'close' });
-    }, [props.value, props.mode]);
+    dispatch({ type: 'close' });
+  }, [props.value, props.mode]);
 
-    const handleSubmit = useCallback(() => {
-      if (props.mode === DateTimePickerMode.Date) {
-        if (state.selectedDate) {
-          props.onChange?.(state.selectedDate);
-        }
-      } else if (state.selectedDate) {
-        const date = state.selectedDate.set({
-          hour: state.selectedHour ?? 0,
-          minute: state.selectedMinute ?? 0,
-          second: 0,
-          millisecond: 0,
-        });
-        props.onChange?.(date);
+  const handleSubmit = useCallback(() => {
+    if (props.mode === DateTimePickerMode.Date) {
+      if (state.selectedDate) {
+        props.onChange?.(state.selectedDate);
       }
+    } else if (state.selectedDate) {
+      const date = state.selectedDate.set({
+        hour: state.selectedHour ?? 0,
+        minute: state.selectedMinute ?? 0,
+        second: 0,
+        millisecond: 0,
+      });
+      props.onChange?.(date);
+    }
+    dispatch({ type: 'close' });
+  }, [
+    props.onChange,
+    props.mode,
+    state.selectedDate,
+    state.selectedHour,
+    state.selectedMinute,
+  ]);
+
+  const handleOkButtonClicked = useCallback(() => {
+    handleSubmit();
+  }, [handleSubmit]);
+
+  const closePopoverContent = useCallback(() => {
+    dispatch({ type: 'close' });
+  }, []);
+
+  const handleOpenChange = useCallback((open: boolean) => {
+    if (open) {
+      dispatch({ type: 'open' });
+    } else {
       dispatch({ type: 'close' });
-    }, [
-      props.onChange,
-      props.mode,
-      state.selectedDate,
-      state.selectedHour,
-      state.selectedMinute,
-    ]);
+    }
+  }, []);
 
-    const handleOkButtonClicked = useCallback(() => {
-      handleSubmit();
-    }, [handleSubmit]);
+  const formattedValue = props.value?.toISO() || '';
 
-    const closePopoverContent = useCallback(() => {
-      dispatch({ type: 'close' });
-    }, []);
+  return (
+    <>
+      {/* A11Y: Live region for screen reader announcements */}
+      <LiveRegion message={liveMessage} />
 
-    const handleOpenChange = useCallback((open: boolean) => {
-      if (open) {
-        dispatch({ type: 'open' });
-      } else {
-        dispatch({ type: 'close' });
-      }
-    }, []);
+      {/* A11Y: Hidden input for form integration */}
+      {props.name && (
+        <input
+          type="hidden"
+          name={props.name}
+          value={formattedValue}
+          required={props.required}
+          aria-hidden="true"
+        />
+      )}
 
-    const formattedValue = props.value?.toISO() || '';
-
-    return (
-      <>
-        {/* A11Y: Live region for screen reader announcements */}
-        <LiveRegion message={liveMessage} />
-
-        {/* A11Y: Hidden input for form integration */}
-        {props.name && (
-          <input
-            type="hidden"
-            name={props.name}
-            value={formattedValue}
-            required={props.required}
-            aria-hidden="true"
-          />
-        )}
-
-        <div className={s.datePicker}>
-          <Popover.Root open={state.isOpen} onOpenChange={handleOpenChange}>
-            <Popover.Trigger>
-              <Button
-                ref={ref}
-                variant="outline"
-                color="gray"
-                className={s.triggerButton}
-                aria-label={
-                  props['aria-label'] ||
+      <div className={s.datePicker}>
+        <Popover.Root open={state.isOpen} onOpenChange={handleOpenChange}>
+          <Popover.Trigger>
+            <Button
+              ref={ref}
+              variant="outline"
+              color="gray"
+              className={s.triggerButton}
+              aria-label={
+                props['aria-label'] ||
+                (props.mode === DateTimePickerMode.DateTime
+                  ? 'Select date & time'
+                  : 'Select date')
+              }
+              aria-describedby={props['aria-describedby']}
+              aria-invalid={props['aria-invalid']}
+              disabled={props.disabled}
+            >
+              {props.value?.toFormat(
+                props.mode === DateTimePickerMode.DateTime
+                  ? 'd LLLL yyyy HH:mm'
+                  : 'd LLLL yyyy',
+              ) ??
+                (props.placeholder ||
                   (props.mode === DateTimePickerMode.DateTime
                     ? 'Select date & time'
-                    : 'Select date')
-                }
-                aria-describedby={props['aria-describedby']}
-                aria-invalid={props['aria-invalid']}
-                disabled={props.disabled}
-              >
-                {props.value?.toFormat(
-                  props.mode === DateTimePickerMode.DateTime
-                    ? 'd LLLL yyyy HH:mm'
-                    : 'd LLLL yyyy',
-                ) ??
-                  (props.placeholder ||
-                    (props.mode === DateTimePickerMode.DateTime
-                      ? 'Select date & time'
-                      : 'Select date'))}
-                {state.isOpen ? (
-                  <ChevronUpIcon aria-hidden="true" />
-                ) : (
-                  <ChevronDownIcon aria-hidden="true" />
-                )}
-              </Button>
-            </Popover.Trigger>
+                    : 'Select date'))}
+              {state.isOpen ? (
+                <ChevronUpIcon aria-hidden="true" />
+              ) : (
+                <ChevronDownIcon aria-hidden="true" />
+              )}
+            </Button>
+          </Popover.Trigger>
 
-            {props.clearable && (
-              <Button
-                variant="outline"
-                color="gray"
-                className={s.clearButton}
-                onClick={handleClearButtonClicked}
-                aria-label="Clear date"
-                disabled={props.disabled || !props.value}
-              >
-                <Cross1Icon aria-hidden="true" />
-              </Button>
-            )}
-
-            <Popover.Content
-              className={s.pickerDialog}
-              align="start"
-              onEscapeKeyDown={closePopoverContent}
-              minWidth="330px"
-              maxWidth="min(480px, 95vw)"
-              avoidCollisions={true}
+          {props.clearable && (
+            <Button
+              variant="outline"
+              color="gray"
+              className={s.clearButton}
+              onClick={handleClearButtonClicked}
+              aria-label="Clear date"
+              disabled={props.disabled || !props.value}
             >
-              <div className={s.calendarAndTime}>
-                <CalendarMonth
-                  yearMonth={state.focusedDate}
-                  focusedDate={state.focusedDate}
-                  selectedDate={state.selectedDate}
-                  onFocusDay={handleFocusDay}
-                  onSelectDay={handleSelectDay}
-                  onHoverDay={handleHoverDay}
-                  max={state.max}
-                  min={state.min}
-                  disabled={props.disabled}
-                  onLiveAnnouncement={setLiveMessage}
-                />
-                {props.mode === DateTimePickerMode.DateTime && (
-                  <TimeSelector
-                    disabled={props.disabled}
-                    focusedHour={state.focusedHour}
-                    focusedMinute={state.focusedMinute}
-                    selectedHour={state.selectedHour}
-                    selectedMinute={state.selectedMinute}
-                    onSelectHour={handleSelectHour}
-                    onSelectMinute={handleSelectMinute}
-                    onFocusHour={handleFocusHour}
-                    onFocusMinute={handleFocusMinute}
-                  />
-                )}
-              </div>
+              <Cross1Icon aria-hidden="true" />
+            </Button>
+          )}
 
-              <div className={s.dialogButtons}>
-                <Button
-                  type="reset"
-                  variant="outline"
+          <Popover.Content
+            className={s.pickerDialog}
+            align="start"
+            onEscapeKeyDown={closePopoverContent}
+            minWidth="330px"
+            maxWidth="min(480px, 95vw)"
+            avoidCollisions={true}
+          >
+            <div className={s.calendarAndTime}>
+              <CalendarMonth
+                yearMonth={state.focusedDate}
+                focusedDate={state.focusedDate}
+                selectedDate={state.selectedDate}
+                onFocusDay={handleFocusDay}
+                onSelectDay={handleSelectDay}
+                onHoverDay={handleHoverDay}
+                max={state.max}
+                min={state.min}
+                disabled={props.disabled}
+                onLiveAnnouncement={setLiveMessage}
+              />
+              {props.mode === DateTimePickerMode.DateTime && (
+                <TimeSelector
                   disabled={props.disabled}
-                  onClick={handleCancelButtonClicked}
-                >
-                  Cancel
-                </Button>
-                <Button
-                  type="button"
-                  disabled={props.disabled}
-                  variant="solid"
-                  onClick={handleOkButtonClicked}
-                >
-                  OK
-                </Button>
-              </div>
-            </Popover.Content>
-          </Popover.Root>
-        </div>
-      </>
-    );
+                  focusedHour={state.focusedHour}
+                  focusedMinute={state.focusedMinute}
+                  selectedHour={state.selectedHour}
+                  selectedMinute={state.selectedMinute}
+                  onSelectHour={handleSelectHour}
+                  onSelectMinute={handleSelectMinute}
+                  onFocusHour={handleFocusHour}
+                  onFocusMinute={handleFocusMinute}
+                />
+              )}
+            </div>
+
+            <div className={s.dialogButtons}>
+              <Button
+                type="reset"
+                variant="outline"
+                disabled={props.disabled}
+                onClick={handleCancelButtonClicked}
+              >
+                Cancel
+              </Button>
+              <Button
+                type="button"
+                disabled={props.disabled}
+                variant="solid"
+                onClick={handleOkButtonClicked}
+              >
+                OK
+              </Button>
+            </div>
+          </Popover.Content>
+        </Popover.Root>
+      </div>
+    </>
+  );
+}
+
+export const DateTimePicker = forwardRef(DateTimePickerInner) as <
+  mode extends DateTimePickerModeType,
+>(
+  props: DatePickerProps<mode> & {
+    ref?: React.ForwardedRef<HTMLButtonElement>;
   },
-);
+) => ReturnType<typeof DateTimePickerInner>;

--- a/src/common/DatePicker2/types.ts
+++ b/src/common/DatePicker2/types.ts
@@ -1,5 +1,5 @@
 import type { DateTimePickerModeType } from './DateTimePickerMode';
-export type DatePickerProps<TMode extends DateTimePickerModeType> = {
+export type DatePickerProps = {
   clearable?: boolean;
   disabled?: boolean;
 
@@ -9,89 +9,46 @@ export type DatePickerProps<TMode extends DateTimePickerModeType> = {
   'aria-invalid'?: boolean; // For validation state
   'aria-label'?: string; // Custom label for trigger button
   placeholder?: string; // Custom placeholder text
-} & DatePickerPropsInner<TMode>;
 
-type DatePickerPropsInner<TMode extends DateTimePickerModeType> =
-  TMode extends 'date'
-    ? {
-        mode: 'date';
-        value: Temporal.PlainDate | undefined;
-        min?: Temporal.PlainDate | undefined;
-        max?: Temporal.PlainDate | undefined;
-        onChange: (value: Temporal.PlainDate | undefined) => void;
-      }
-    : {
-        mode: 'datetime';
-        value: Temporal.PlainDateTime | undefined;
-        min?: Temporal.PlainDateTime | undefined;
-        max?: Temporal.PlainDateTime | undefined;
-        onChange: (value: Temporal.PlainDateTime | undefined) => void;
-      };
+  mode: DateTimePickerModeType;
+  value: Temporal.PlainDate | Temporal.PlainDateTime | undefined;
+  min?: Temporal.PlainDate | Temporal.PlainDateTime | undefined;
+  max?: Temporal.PlainDate | Temporal.PlainDateTime | undefined;
+  onChange: (
+    value: Temporal.PlainDate | Temporal.PlainDateTime | undefined,
+  ) => void;
+};
 
-export type DatePickerState<TMode extends DateTimePickerModeType> = {
+export type DatePickerState = {
   isOpen: boolean;
+  focusedDate: Temporal.PlainDate | Temporal.PlainDateTime;
+  selectedDate: Temporal.PlainDate | Temporal.PlainDateTime | undefined;
+  hoveredDate: Temporal.PlainDate | Temporal.PlainDateTime | undefined;
+  min: Temporal.PlainDate | Temporal.PlainDateTime | undefined;
+  max: Temporal.PlainDate | Temporal.PlainDateTime | undefined;
   focusedHour: number | undefined;
   focusedMinute: number | undefined;
   selectedHour: number | undefined;
   selectedMinute: number | undefined;
-} & DatePickerStateInner<TMode>;
-type DatePickerStateInner<TMode extends DateTimePickerModeType> =
-  TMode extends 'date'
-    ? {
-        focusedDate: Temporal.PlainDate | undefined;
-        selectedDate: Temporal.PlainDate | undefined;
-        hoveredDate: Temporal.PlainDate | undefined;
-        selectedDateTime: Temporal.PlainDate | undefined;
-        min: Temporal.PlainDate | undefined;
-        max: Temporal.PlainDate | undefined;
-      }
-    : {
-        focusedDate: Temporal.PlainDateTime | undefined;
-        selectedDate: Temporal.PlainDateTime | undefined;
-        hoveredDate: Temporal.PlainDateTime | undefined;
-        selectedDateTime: Temporal.PlainDateTime | undefined;
-        min: Temporal.PlainDateTime | undefined;
-        max: Temporal.PlainDateTime | undefined;
-      };
-
-export type DatePickerAction<TMode extends DateTimePickerModeType> =
-  | (
-      | { type: 'setSelectedHour'; hour: number }
-      | { type: 'setSelectedMinute'; minute: number }
-      | { type: 'setFocusedHour'; hour: number }
-      | { type: 'setFocusedMinute'; minute: number }
-      | { type: 'clear' }
-      | { type: 'toggle' }
-      | { type: 'open' }
-      | { type: 'close' }
-    )
-  | DatePickerActionInner<TMode>;
-
-type DatePickerActionInner<TMode extends DateTimePickerModeType> =
-  TMode extends 'date'
-    ?
-        | {
-            type: 'setFocusedDate';
-            date: Temporal.PlainDate | undefined;
-          }
-        | {
-            type: 'setSelectedDate';
-            date: Temporal.PlainDate | undefined;
-          }
-        | {
-            type: 'setHoveredDate';
-            date: Temporal.PlainDate | undefined;
-          }
-    :
-        | {
-            type: 'setFocusedDate';
-            date: Temporal.PlainDateTime | undefined;
-          }
-        | {
-            type: 'setSelectedDate';
-            date: Temporal.PlainDateTime | undefined;
-          }
-        | {
-            type: 'setHoveredDate';
-            date: Temporal.PlainDateTime | undefined;
-          };
+};
+export type DatePickerAction =
+  | {
+      type: 'setFocusedDate';
+      date: Temporal.PlainDate | Temporal.PlainDateTime | undefined;
+    }
+  | {
+      type: 'setSelectedDate';
+      date: Temporal.PlainDate | Temporal.PlainDateTime | undefined;
+    }
+  | {
+      type: 'setHoveredDate';
+      date: Temporal.PlainDate | Temporal.PlainDateTime | undefined;
+    }
+  | { type: 'setSelectedHour'; hour: number }
+  | { type: 'setSelectedMinute'; minute: number }
+  | { type: 'setFocusedHour'; hour: number }
+  | { type: 'setFocusedMinute'; minute: number }
+  | { type: 'clear' }
+  | { type: 'toggle' }
+  | { type: 'open' }
+  | { type: 'close' };

--- a/src/common/DatePicker2/types.ts
+++ b/src/common/DatePicker2/types.ts
@@ -1,13 +1,6 @@
-import type { DateTime } from 'luxon';
 import type { DateTimePickerModeType } from './DateTimePickerMode';
-
-export interface DatePickerProps {
-  value: DateTime | undefined;
-  min?: DateTime;
-  max?: DateTime;
-  mode: DateTimePickerModeType;
+export type DatePickerProps<TMode extends DateTimePickerModeType> = {
   clearable?: boolean;
-  onChange: (value: DateTime | undefined) => void;
   disabled?: boolean;
 
   name?: string; // For form submission
@@ -16,32 +9,89 @@ export interface DatePickerProps {
   'aria-invalid'?: boolean; // For validation state
   'aria-label'?: string; // Custom label for trigger button
   placeholder?: string; // Custom placeholder text
-}
+} & DatePickerPropsInner<TMode>;
 
-export interface DatePickerState {
+type DatePickerPropsInner<TMode extends DateTimePickerModeType> =
+  TMode extends 'date'
+    ? {
+        mode: 'date';
+        value: Temporal.PlainDate | undefined;
+        min?: Temporal.PlainDate | undefined;
+        max?: Temporal.PlainDate | undefined;
+        onChange: (value: Temporal.PlainDate | undefined) => void;
+      }
+    : {
+        mode: 'datetime';
+        value: Temporal.PlainDateTime | undefined;
+        min?: Temporal.PlainDateTime | undefined;
+        max?: Temporal.PlainDateTime | undefined;
+        onChange: (value: Temporal.PlainDateTime | undefined) => void;
+      };
+
+export type DatePickerState<TMode extends DateTimePickerModeType> = {
   isOpen: boolean;
-  focusedDate: DateTime;
-  selectedDate: DateTime | undefined;
-  hoveredDate: DateTime | undefined;
-  min: DateTime | undefined;
-  max: DateTime | undefined;
-
   focusedHour: number | undefined;
   focusedMinute: number | undefined;
   selectedHour: number | undefined;
   selectedMinute: number | undefined;
+} & DatePickerStateInner<TMode>;
+type DatePickerStateInner<TMode extends DateTimePickerModeType> =
+  TMode extends 'date'
+    ? {
+        focusedDate: Temporal.PlainDate | undefined;
+        selectedDate: Temporal.PlainDate | undefined;
+        hoveredDate: Temporal.PlainDate | undefined;
+        selectedDateTime: Temporal.PlainDate | undefined;
+        min: Temporal.PlainDate | undefined;
+        max: Temporal.PlainDate | undefined;
+      }
+    : {
+        focusedDate: Temporal.PlainDateTime | undefined;
+        selectedDate: Temporal.PlainDateTime | undefined;
+        hoveredDate: Temporal.PlainDateTime | undefined;
+        selectedDateTime: Temporal.PlainDateTime | undefined;
+        min: Temporal.PlainDateTime | undefined;
+        max: Temporal.PlainDateTime | undefined;
+      };
 
-  selectedDateTime: DateTime | undefined;
-}
-export type DatePickerAction =
-  | { type: 'setFocusedDate'; date: DateTime }
-  | { type: 'setSelectedDate'; date: DateTime }
-  | { type: 'setHoveredDate'; date: DateTime }
-  | { type: 'setSelectedHour'; hour: number }
-  | { type: 'setSelectedMinute'; minute: number }
-  | { type: 'setFocusedHour'; hour: number }
-  | { type: 'setFocusedMinute'; minute: number }
-  | { type: 'clear' }
-  | { type: 'toggle' }
-  | { type: 'open' }
-  | { type: 'close' };
+export type DatePickerAction<TMode extends DateTimePickerModeType> =
+  | (
+      | { type: 'setSelectedHour'; hour: number }
+      | { type: 'setSelectedMinute'; minute: number }
+      | { type: 'setFocusedHour'; hour: number }
+      | { type: 'setFocusedMinute'; minute: number }
+      | { type: 'clear' }
+      | { type: 'toggle' }
+      | { type: 'open' }
+      | { type: 'close' }
+    )
+  | DatePickerActionInner<TMode>;
+
+type DatePickerActionInner<TMode extends DateTimePickerModeType> =
+  TMode extends 'date'
+    ?
+        | {
+            type: 'setFocusedDate';
+            date: Temporal.PlainDate | undefined;
+          }
+        | {
+            type: 'setSelectedDate';
+            date: Temporal.PlainDate | undefined;
+          }
+        | {
+            type: 'setHoveredDate';
+            date: Temporal.PlainDate | undefined;
+          }
+    :
+        | {
+            type: 'setFocusedDate';
+            date: Temporal.PlainDateTime | undefined;
+          }
+        | {
+            type: 'setSelectedDate';
+            date: Temporal.PlainDateTime | undefined;
+          }
+        | {
+            type: 'setHoveredDate';
+            date: Temporal.PlainDateTime | undefined;
+          };

--- a/src/common/DatePicker2/types.ts
+++ b/src/common/DatePicker2/types.ts
@@ -11,21 +11,23 @@ export type DatePickerProps = {
   placeholder?: string; // Custom placeholder text
 
   mode: DateTimePickerModeType;
+  /** value will be PlainDate if mode is 'date'; value will be PlainDateTime if mode is 'datetime'; value will be undefined if it is cleared */
   value: Temporal.PlainDate | Temporal.PlainDateTime | undefined;
-  min?: Temporal.PlainDate | Temporal.PlainDateTime | undefined;
-  max?: Temporal.PlainDate | Temporal.PlainDateTime | undefined;
+  min?: Temporal.PlainDate | undefined;
+  max?: Temporal.PlainDate | undefined;
   onChange: (
+    /** value will be PlainDate if mode is 'date'; value will be PlainDateTime if mode is 'datetime'; value will be undefined if it is cleared */
     value: Temporal.PlainDate | Temporal.PlainDateTime | undefined,
   ) => void;
 };
 
 export type DatePickerState = {
   isOpen: boolean;
-  focusedDate: Temporal.PlainDate | Temporal.PlainDateTime;
-  selectedDate: Temporal.PlainDate | Temporal.PlainDateTime | undefined;
-  hoveredDate: Temporal.PlainDate | Temporal.PlainDateTime | undefined;
-  min: Temporal.PlainDate | Temporal.PlainDateTime | undefined;
-  max: Temporal.PlainDate | Temporal.PlainDateTime | undefined;
+  focusedDate: Temporal.PlainDate;
+  selectedDate: Temporal.PlainDate | undefined;
+  hoveredDate: Temporal.PlainDate | undefined;
+  min: Temporal.PlainDate | undefined;
+  max: Temporal.PlainDate | undefined;
   focusedHour: number | undefined;
   focusedMinute: number | undefined;
   selectedHour: number | undefined;
@@ -34,15 +36,15 @@ export type DatePickerState = {
 export type DatePickerAction =
   | {
       type: 'setFocusedDate';
-      date: Temporal.PlainDate | Temporal.PlainDateTime | undefined;
+      date: Temporal.PlainDate;
     }
   | {
       type: 'setSelectedDate';
-      date: Temporal.PlainDate | Temporal.PlainDateTime | undefined;
+      date: Temporal.PlainDate;
     }
   | {
       type: 'setHoveredDate';
-      date: Temporal.PlainDate | Temporal.PlainDateTime | undefined;
+      date: Temporal.PlainDate;
     }
   | { type: 'setSelectedHour'; hour: number }
   | { type: 'setSelectedMinute'; minute: number }

--- a/src/common/dateTime/luxonTemporalConverter.ts
+++ b/src/common/dateTime/luxonTemporalConverter.ts
@@ -1,0 +1,56 @@
+import { DateTime } from 'luxon';
+
+export function luxonToTemporalDateTime(
+  luxonDateTime: DateTime,
+): Temporal.PlainDateTime {
+  return Temporal.PlainDateTime.from({
+    year: luxonDateTime.year,
+    month: luxonDateTime.month,
+    day: luxonDateTime.day,
+    hour: luxonDateTime.hour,
+    minute: luxonDateTime.minute,
+    second: luxonDateTime.second,
+    millisecond: luxonDateTime.millisecond,
+  });
+}
+
+export function luxonToTemporalDate(
+  luxonDateTime: DateTime,
+): Temporal.PlainDate {
+  return Temporal.PlainDate.from({
+    year: luxonDateTime.year,
+    month: luxonDateTime.month,
+    day: luxonDateTime.day,
+  });
+}
+
+export function temporalToLuxonDateTime(
+  temporalDateTime: Temporal.PlainDateTime,
+  timeZone?: string,
+): DateTime {
+  return DateTime.fromObject(
+    {
+      year: temporalDateTime.year,
+      month: temporalDateTime.month,
+      day: temporalDateTime.day,
+      hour: temporalDateTime.hour,
+      minute: temporalDateTime.minute,
+      second: temporalDateTime.second,
+      millisecond: temporalDateTime.millisecond,
+    },
+    { zone: timeZone || 'local' },
+  );
+}
+export function temporalToLuxonDate(
+  temporalDate: Temporal.PlainDate,
+  timeZone?: string,
+): DateTime {
+  return DateTime.fromObject(
+    {
+      year: temporalDate.year,
+      month: temporalDate.month,
+      day: temporalDate.day,
+    },
+    { zone: timeZone || 'local' },
+  );
+}

--- a/src/common/dateTime/temporalFormatter.ts
+++ b/src/common/dateTime/temporalFormatter.ts
@@ -3,6 +3,7 @@
 // https://moment.github.io/luxon/#/formatting
 // https://github.com/moment/luxon/blob/b6b9d03709085008287ed7f4ce5067f0f4be53f2/src/impl/tokenParser.js#L432
 // Idea: Use Int.DateTimeFormat
+// TODO: I don't like this... we should do something like toFormat([TOKEN.YEAR_FULL, ' ', TOKEN.MONTH_SHORT, ' ', TOKEN.DAY_OF_MONTH_2_DIGIT], temporal) instead of parsing a string format. This would be more type-safe and avoid parsing errors. But for now, this is good enough.
 type SupportedTemporal = Temporal.PlainDate | Temporal.PlainDateTime;
 
 const TOKENS = [

--- a/src/common/dateTime/temporalFormatter.ts
+++ b/src/common/dateTime/temporalFormatter.ts
@@ -1,0 +1,52 @@
+// Inspired by Luxon token formatter
+// Only implement subset of tokens that are used in this project
+// https://moment.github.io/luxon/#/formatting
+// https://github.com/moment/luxon/blob/b6b9d03709085008287ed7f4ce5067f0f4be53f2/src/impl/tokenParser.js#L432
+// Idea: Use Int.DateTimeFormat
+
+function intlOption(token: string): Intl.DateTimeFormatOptions {
+  switch (token) {
+    case 'yyyy':
+      return { year: 'numeric' };
+    case 'MM':
+    case 'LL':
+      return { month: '2-digit' };
+    case 'MMM':
+    case 'LLL':
+      return { month: 'short' };
+    case 'MMMM':
+    case 'LLLL':
+      return { month: 'long' };
+    case 'dd':
+      return { day: '2-digit' };
+    case 'd':
+      return { day: 'numeric' };
+    case 'HH':
+      return { hour: '2-digit', hour12: false };
+    case 'H':
+      return { hour: 'numeric', hour12: false };
+    case 'hh':
+      return { hour: '2-digit', hour12: true };
+    case 'h':
+      return { hour: 'numeric', hour12: true };
+    case 'mm':
+      return { minute: '2-digit' };
+    case 'ss':
+      return { second: '2-digit' };
+    default:
+      throw new Error(`Unsupported token: ${token}`);
+  }
+}
+
+export function toFormat(
+  format: string,
+  temporal: Temporal.PlainDate | Temporal.PlainDateTime,
+): string {
+  for (let i = 0; i < format.length; i++) {
+    const char = format.charAt(i);
+    
+  }
+
+
+  return '';
+}

--- a/src/common/dateTime/temporalFormatter.ts
+++ b/src/common/dateTime/temporalFormatter.ts
@@ -3,50 +3,246 @@
 // https://moment.github.io/luxon/#/formatting
 // https://github.com/moment/luxon/blob/b6b9d03709085008287ed7f4ce5067f0f4be53f2/src/impl/tokenParser.js#L432
 // Idea: Use Int.DateTimeFormat
+type SupportedTemporal = Temporal.PlainDate | Temporal.PlainDateTime;
 
-function intlOption(token: string): Intl.DateTimeFormatOptions {
+const TOKENS = [
+  'yyyy',
+  'MMMM',
+  'LLLL',
+  'cccc',
+  'MMM',
+  'LLL',
+  'MM',
+  'LL',
+  'dd',
+  'HH',
+  'hh',
+  'mm',
+  'ss',
+  'd',
+  'H',
+  'h',
+  'm',
+  's',
+  'a',
+] as const;
+
+type Token = (typeof TOKENS)[number];
+
+function isPlainDateTime(
+  temporal: SupportedTemporal,
+): temporal is Temporal.PlainDateTime {
+  return 'hour' in temporal;
+}
+
+/**
+ * Converts the Temporal value to a Date without applying the local time zone.
+ *
+ * The Date is only used as an Intl.DateTimeFormat input. Formatting is always
+ * done in UTC, so the Temporal wall-clock fields remain unchanged.
+ */
+function toSurrogateDate(temporal: SupportedTemporal): Date {
+  const date = new Date(0);
+
+  date.setUTCFullYear(temporal.year, temporal.month - 1, temporal.day);
+
+  if (isPlainDateTime(temporal)) {
+    date.setUTCHours(
+      temporal.hour,
+      temporal.minute,
+      temporal.second,
+      temporal.millisecond,
+    );
+  } else {
+    date.setUTCHours(0, 0, 0, 0);
+  }
+
+  return date;
+}
+
+function formatNumber(
+  value: number,
+  minimumIntegerDigits: number,
+  locales?: Intl.LocalesArgument,
+): string {
+  return new Intl.NumberFormat(locales, {
+    useGrouping: false,
+    minimumIntegerDigits,
+  }).format(value);
+}
+
+function formatMonthName(
+  temporal: SupportedTemporal,
+  width: 'short' | 'long',
+  locales?: Intl.LocalesArgument,
+): string {
+  const formatter = new Intl.DateTimeFormat(locales, {
+    month: width,
+    timeZone: 'UTC',
+  });
+
+  const monthPart = formatter
+    .formatToParts(toSurrogateDate(temporal))
+    .find((part) => part.type === 'month');
+
+  if (!monthPart) {
+    throw new Error('Intl.DateTimeFormat did not produce a month part');
+  }
+
+  return monthPart.value;
+}
+
+function formatWeekdayName(
+  temporal: SupportedTemporal,
+  width: 'short' | 'long',
+  locales?: Intl.LocalesArgument,
+): string {
+  const formatter = new Intl.DateTimeFormat(locales, {
+    weekday: width,
+    timeZone: 'UTC',
+  });
+  const weekdayPart = formatter
+    .formatToParts(toSurrogateDate(temporal))
+    .find((part) => part.type === 'weekday');
+
+  if (!weekdayPart) {
+    throw new Error('Intl.DateTimeFormat did not produce a weekday part');
+  }
+  return weekdayPart.value;
+}
+
+function formatToken(
+  token: Token,
+  temporal: SupportedTemporal,
+  locales?: Intl.LocalesArgument,
+): string {
   switch (token) {
     case 'yyyy':
-      return { year: 'numeric' };
+      return formatNumber(temporal.year, 4, locales);
+
     case 'MM':
     case 'LL':
-      return { month: '2-digit' };
+      return formatNumber(temporal.month, 2, locales);
+
     case 'MMM':
     case 'LLL':
-      return { month: 'short' };
+      return formatMonthName(temporal, 'short', locales);
+
     case 'MMMM':
     case 'LLLL':
-      return { month: 'long' };
+      return formatMonthName(temporal, 'long', locales);
+
+    case 'cccc':
+      return formatWeekdayName(temporal, 'long', locales);
+
     case 'dd':
-      return { day: '2-digit' };
+      return formatNumber(temporal.day, 2, locales);
+
     case 'd':
-      return { day: 'numeric' };
-    case 'HH':
-      return { hour: '2-digit', hour12: false };
-    case 'H':
-      return { hour: 'numeric', hour12: false };
-    case 'hh':
-      return { hour: '2-digit', hour12: true };
-    case 'h':
-      return { hour: 'numeric', hour12: true };
-    case 'mm':
-      return { minute: '2-digit' };
-    case 'ss':
-      return { second: '2-digit' };
-    default:
-      throw new Error(`Unsupported token: ${token}`);
+      return formatNumber(temporal.day, 1, locales);
   }
+
+  if (!isPlainDateTime(temporal)) {
+    throw new RangeError(`Token "${token}" requires Temporal.PlainDateTime`);
+  }
+
+  switch (token) {
+    case 'HH':
+      return formatNumber(temporal.hour, 2, locales);
+
+    case 'H':
+      return formatNumber(temporal.hour, 1, locales);
+
+    case 'hh':
+      return formatNumber(temporal.hour % 12 || 12, 2, locales);
+
+    case 'h':
+      return formatNumber(temporal.hour % 12 || 12, 1, locales);
+
+    case 'mm':
+      return formatNumber(temporal.minute, 2, locales);
+
+    case 'm':
+      return formatNumber(temporal.minute, 1, locales);
+
+    case 'ss':
+      return formatNumber(temporal.second, 2, locales);
+
+    case 's':
+      return formatNumber(temporal.second, 1, locales);
+
+    case 'a':
+      return temporal.hour < 12 ? 'AM' : 'PM';
+  }
+}
+
+function readQuotedLiteral(
+  format: string,
+  start: number,
+): { value: string; nextIndex: number } {
+  let value = '';
+  let index = start + 1;
+
+  while (index < format.length) {
+    if (format[index] !== "'") {
+      value += format[index];
+      index++;
+      continue;
+    }
+
+    // Two consecutive apostrophes inside a quoted section represent one
+    // literal apostrophe.
+    if (format[index + 1] === "'") {
+      value += "'";
+      index += 2;
+      continue;
+    }
+
+    return {
+      value,
+      nextIndex: index + 1,
+    };
+  }
+
+  throw new RangeError(`Unterminated quoted literal at index ${start}`);
 }
 
 export function toFormat(
   format: string,
-  temporal: Temporal.PlainDate | Temporal.PlainDateTime,
+  temporal: SupportedTemporal,
+  locales?: Intl.LocalesArgument,
 ): string {
-  for (let i = 0; i < format.length; i++) {
-    const char = format.charAt(i);
-    
+  let result = '';
+  let index = 0;
+
+  while (index < format.length) {
+    if (format[index] === "'") {
+      // Outside a quoted section, two apostrophes also produce one apostrophe.
+      if (format[index + 1] === "'") {
+        result += "'";
+        index += 2;
+        continue;
+      }
+
+      const literal = readQuotedLiteral(format, index);
+      result += literal.value;
+      index = literal.nextIndex;
+      continue;
+    }
+
+    const token = TOKENS.find((candidate) =>
+      format.startsWith(candidate, index),
+    );
+
+    if (token) {
+      result += formatToken(token, temporal, locales);
+      index += token.length;
+      continue;
+    }
+
+    result += format[index];
+    index++;
   }
 
-
-  return '';
+  return result;
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,3 +1,4 @@
+import './polyfills/temporal';
 import './index.css';
 import { reactErrorHandler, init as sentryInit } from '@sentry/react';
 // import { StrictMode } from 'react';

--- a/src/polyfills/temporal.ts
+++ b/src/polyfills/temporal.ts
@@ -1,0 +1,6 @@
+// Only load temporal polyfill if it's not already available in the environment
+if (!('Temporal' in globalThis)) {
+  await import('temporal-polyfill/global');
+}
+
+export {};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "lib": ["DOM", "ES2022"],
+    "lib": ["DOM", "ESNext"],
     "jsx": "react-jsx",
-    "target": "ES2022",
+    "target": "ESNext",
     "noEmit": true,
     "skipLibCheck": true,
     "useDefineForClassFields": true,

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,4 +1,6 @@
 import '@testing-library/jest-dom/vitest';
+// TODO: Node.js only supports Temporal since v26 but it's not LTS yet at time of writing (2026-07-13)
+import 'temporal-polyfill/global';
 import { cleanup } from '@testing-library/react';
 import { afterEach } from 'vitest';
 


### PR DESCRIPTION
Introduce Temporal to be used in Datepicker. Load Temporal polyfill if browser does not support it (at time of writing, only Safari)

The fundamental flaw of current Datepicker was that it represents internal state as timestamp, however, when picking dates, user does not expect it to be timestamp, but as 'wall clock' or 'plain date'. So Temporal.PlainDate fits very naturally here

Probably will try to move away from Luxon and use Temporal in the future

- [x] Change internal state of DatePicker to Temporal PlainDate/PlainDateTime
- [x] Custom date/time formatting for DatePicker/CalendarMonth
- [x] Adapt demo
- [x] Adapt for TripForm
- [x] Adapt for ExpenseForm
- [x] Adapt for ActivityForm
- [x] Adapt for MacroplanForm
- [x] Adapt for AccommodationForm
- [x] Adapt for FlightForm

Fixes #139 

Fixes #141 