### PR TITLE
feat(timetable): only mount drag targets near viewport

### DIFF
--- a/src/Activity/Activity.tsx
+++ b/src/Activity/Activity.tsx
@@ -409,115 +409,117 @@ function ActivityInner({
     activity.timestampEnd,
   ]);
 
+  const activityContent = (
+    <Box
+      p={{ initial: '1' }}
+      as="div"
+      role="button"
+      tabIndex={0}
+      ref={activityRef}
+      className={clsx(
+        style.activity,
+        isActivityOngoing ? style.activityOngoing : '',
+        timetableDragging.dragging &&
+          timetableDragging.source.activityId === activity.id
+          ? timetableDragging.source.mode === 'drag'
+            ? style.activityDragging
+            : style.activityResizing
+          : '',
+        className,
+      )}
+      onClick={handleClick}
+      onKeyDown={handleKeyDown}
+      onKeyUp={handleKeyUp}
+      draggable={
+        tripViewMode === TripViewMode.Timetable &&
+        userCanEditOrDelete &&
+        !isDragAndDropDisabled
+      }
+      onDragStart={handleDragStart}
+      onDragEnd={handleDragEnd}
+      style={boxStyle}
+    >
+      {tripViewMode === TripViewMode.List ? (
+        <Text
+          as="div"
+          size={responsiveTextSize}
+          color="gray"
+          className={style.activityTime}
+        >
+          <ClockIcon style={{ verticalAlign: '-2px' }} />{' '}
+          {timeStartRelativeToTrip} - {timeEndRelativeToTrip}
+        </Text>
+      ) : null}
+      {tripViewMode === TripViewMode.Home ? (
+        <Text
+          as="div"
+          size={responsiveTextSize}
+          color="gray"
+          className={style.activityTime}
+        >
+          <ClockIcon style={{ verticalAlign: '-2px' }} /> {activityTimeStr}
+        </Text>
+      ) : null}
+
+      <Text
+        as="div"
+        size={responsiveTextSize}
+        weight="bold"
+        className={style.activityTitle}
+      >
+        {activityTitle}
+      </Text>
+
+      {activity.location ? (
+        <Text
+          as="div"
+          size={responsiveTextSize}
+          color="gray"
+          className={style.activityLocation}
+        >
+          <SewingPinIcon style={{ verticalAlign: '-2px' }} />{' '}
+          {activity.location}
+          {activity.locationDestination
+            ? ` → ${activity.locationDestination}`
+            : null}
+        </Text>
+      ) : null}
+
+      {activity.description ? (
+        <Text
+          as="div"
+          size={responsiveTextSize}
+          color="gray"
+          className={style.activityDescription}
+        >
+          <InfoCircledIcon style={{ verticalAlign: '-2px' }} />{' '}
+          {activity.description}
+        </Text>
+      ) : null}
+
+      {isActivityResizable ? (
+        // biome-ignore lint/a11y/noStaticElementInteractions: indicator for resizing
+        <div
+          className={style.activityResizeHint}
+          onDragStart={handleResizeStart}
+          draggable={
+            tripViewMode === TripViewMode.Timetable &&
+            userCanEditOrDelete &&
+            !isDragAndDropDisabled
+          }
+        />
+      ) : null}
+    </Box>
+  );
+
   return (
     <ContextMenu.Root>
       <ContextMenu.Trigger>
-        <TooltipForSmallActivity
-          content={activityTitle}
-          isSmallActivity={isSmallActivity}
-        >
-          <Box
-            p={{ initial: '1' }}
-            as="div"
-            role="button"
-            tabIndex={0}
-            ref={activityRef}
-            className={clsx(
-              style.activity,
-              isActivityOngoing ? style.activityOngoing : '',
-              timetableDragging.dragging &&
-                timetableDragging.source.activityId === activity.id
-                ? timetableDragging.source.mode === 'drag'
-                  ? style.activityDragging
-                  : style.activityResizing
-                : '',
-              className,
-            )}
-            onClick={handleClick}
-            onKeyDown={handleKeyDown}
-            onKeyUp={handleKeyUp}
-            draggable={
-              tripViewMode === TripViewMode.Timetable &&
-              userCanEditOrDelete &&
-              !isDragAndDropDisabled
-            }
-            onDragStart={handleDragStart}
-            onDragEnd={handleDragEnd}
-            style={boxStyle}
-          >
-            {tripViewMode === TripViewMode.List ? (
-              <Text
-                as="div"
-                size={responsiveTextSize}
-                color="gray"
-                className={style.activityTime}
-              >
-                <ClockIcon style={{ verticalAlign: '-2px' }} />{' '}
-                {timeStartRelativeToTrip} - {timeEndRelativeToTrip}
-              </Text>
-            ) : null}
-            {tripViewMode === TripViewMode.Home ? (
-              <Text
-                as="div"
-                size={responsiveTextSize}
-                color="gray"
-                className={style.activityTime}
-              >
-                <ClockIcon style={{ verticalAlign: '-2px' }} />{' '}
-                {activityTimeStr}
-              </Text>
-            ) : null}
-
-            <Text
-              as="div"
-              size={responsiveTextSize}
-              weight="bold"
-              className={style.activityTitle}
-            >
-              {activityTitle}
-            </Text>
-
-            {activity.location ? (
-              <Text
-                as="div"
-                size={responsiveTextSize}
-                color="gray"
-                className={style.activityLocation}
-              >
-                <SewingPinIcon style={{ verticalAlign: '-2px' }} />{' '}
-                {activity.location}
-                {activity.locationDestination
-                  ? ` → ${activity.locationDestination}`
-                  : null}
-              </Text>
-            ) : null}
-
-            {activity.description ? (
-              <Text
-                as="div"
-                size={responsiveTextSize}
-                color="gray"
-                className={style.activityDescription}
-              >
-                <InfoCircledIcon style={{ verticalAlign: '-2px' }} />{' '}
-                {activity.description}
-              </Text>
-            ) : null}
-
-            {isActivityResizable ? (
-              // biome-ignore lint/a11y/noStaticElementInteractions: indicator for resizing
-              <div
-                className={style.activityResizeHint}
-                onDragStart={handleResizeStart}
-                draggable={
-                  tripViewMode === TripViewMode.Timetable &&
-                  userCanEditOrDelete &&
-                  !isDragAndDropDisabled
-                }
-              />
-            ) : null}
-          </Box>
-        </TooltipForSmallActivity>
+        {isSmallActivity ? (
+          <Tooltip content={activityTitle}>{activityContent}</Tooltip>
+        ) : (
+          activityContent
+        )}
       </ContextMenu.Trigger>
       <ContextMenu.Content>
         <ContextMenu.Label>{activityTitle}</ContextMenu.Label>
@@ -547,21 +549,6 @@ function ActivityInner({
       </ContextMenu.Content>
     </ContextMenu.Root>
   );
-}
-
-function TooltipForSmallActivity({
-  content,
-  isSmallActivity,
-  children,
-}: {
-  content: string;
-  isSmallActivity: boolean;
-  children: React.ReactNode;
-}) {
-  if (isSmallActivity) {
-    return <Tooltip content={content}>{children}</Tooltip>;
-  }
-  return <>{children}</>;
 }
 
 export const Activity = memo(ActivityInner, (prevProps, nextProps) => {

--- a/src/Trip/TripTimetableView/Timetable.tsx
+++ b/src/Trip/TripTimetableView/Timetable.tsx
@@ -534,7 +534,10 @@ export function Timetable() {
         ref={timetableRef}
         onDrop={handleDrop}
       >
-        <TimetableGrid days={dayGroups.inTrip.length} />
+        <TimetableGrid
+          days={dayGroups.inTrip.length}
+          scrollContainerRef={timetableRef}
+        />
         <TimetableTimeHeader />
         {dayGroups.inTrip.map((dayGroup, i) => {
           const dayNumber = i + 1;

--- a/src/Trip/TripTimetableView/TimetableCell.tsx
+++ b/src/Trip/TripTimetableView/TimetableCell.tsx
@@ -1,50 +1,59 @@
 import clsx from 'clsx';
-import type React from 'react';
-import { useCallback, useState } from 'react';
+import type { ComponentPropsWithoutRef, DragEvent } from 'react';
+import { forwardRef, useCallback, useState } from 'react';
 import { useTripTimetableDragging } from '../store/hooks';
 import s from './Timetable.module.scss';
 
-interface TimetableCellProps {
+interface TimetableCellProps extends ComponentPropsWithoutRef<'div'> {
   row: string;
   column: string;
-  children?: React.ReactNode;
 }
 
-export function TimetableCell({ row, column, children }: TimetableCellProps) {
-  const [isDragOver, setIsDragOver] = useState(false);
-  const { timetableDragging } = useTripTimetableDragging();
+export const TimetableCell = forwardRef<HTMLDivElement, TimetableCellProps>(
+  function TimetableCell({ row, column, children, className, ...props }, ref) {
+    const [isDragOver, setIsDragOver] = useState(false);
+    const { timetableDragging } = useTripTimetableDragging();
 
-  const handleDragOver = useCallback(
-    (e: React.DragEvent<HTMLDivElement>) => {
-      e.preventDefault();
-      e.dataTransfer.dropEffect = 'move';
+    const handleDragOver = useCallback(
+      (e: DragEvent<HTMLDivElement>) => {
+        e.preventDefault();
+        e.dataTransfer.dropEffect = 'move';
 
-      if (!isDragOver) {
-        setIsDragOver(true);
-      }
-    },
-    [isDragOver],
-  );
+        if (!isDragOver) {
+          setIsDragOver(true);
+        }
+      },
+      [isDragOver],
+    );
 
-  const handleDragLeave = useCallback(() => {
-    setIsDragOver(false);
-  }, []);
+    const handleDragLeave = useCallback(() => {
+      setIsDragOver(false);
+    }, []);
 
-  return (
-    // biome-ignore lint/a11y/noStaticElementInteractions: Drag-and-drop events are used
-    <div
-      className={clsx(s.timetableCell, {
-        [s.dragging]: isDragOver && timetableDragging.source.mode === 'drag',
-        [s.resizing]: isDragOver && timetableDragging.source.mode === 'resize',
-      })}
-      data-grid-cell={true}
-      data-grid-row={row}
-      data-grid-column={column}
-      onDragOver={handleDragOver}
-      onDragLeave={handleDragLeave}
-      onDrop={handleDragLeave}
-    >
-      {children}
-    </div>
-  );
-}
+    return (
+      // biome-ignore lint/a11y/noStaticElementInteractions: Drag-and-drop events are used
+      <div
+        {...props}
+        ref={ref}
+        className={clsx(
+          s.timetableCell,
+          {
+            [s.dragging]:
+              isDragOver && timetableDragging.source.mode === 'drag',
+            [s.resizing]:
+              isDragOver && timetableDragging.source.mode === 'resize',
+          },
+          className,
+        )}
+        data-grid-cell={true}
+        data-grid-row={row}
+        data-grid-column={column}
+        onDragOver={handleDragOver}
+        onDragLeave={handleDragLeave}
+        onDrop={handleDragLeave}
+      >
+        {children}
+      </div>
+    );
+  },
+);

--- a/src/Trip/TripTimetableView/TimetableDragTarget.test.tsx
+++ b/src/Trip/TripTimetableView/TimetableDragTarget.test.tsx
@@ -1,0 +1,63 @@
+import { Theme } from '@radix-ui/themes';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { TimetableDragTarget } from './TimetableDragTarget';
+
+vi.mock('../store/hooks', () => ({
+  useTripTimetableDragging: () => ({
+    timetableDragging: { source: { mode: undefined } },
+  }),
+}));
+
+class MockIntersectionObserver {
+  constructor(readonly callback: IntersectionObserverCallback) {}
+
+  observe(target: Element) {
+    this.callback(
+      [{ isIntersecting: true, target } as IntersectionObserverEntry],
+      this as never,
+    );
+  }
+
+  unobserve() {}
+}
+
+describe('TimetableDragTarget', () => {
+  beforeEach(() => {
+    vi.stubGlobal('IntersectionObserver', MockIntersectionObserver);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  test('opens its context menu when its cell is right-clicked', async () => {
+    render(
+      <Theme>
+        <TimetableDragTarget
+          day={1}
+          timeStr="0900"
+          columnStr="d1-c1"
+          gridStyle={{}}
+          scrollContainerRef={{ current: null }}
+          userCanModifyTrip={true}
+          onNewActivity={vi.fn()}
+          onNewFlight={vi.fn()}
+          onNewTrain={vi.fn()}
+          onNewAccommodation={vi.fn()}
+          onNewMacroplan={vi.fn()}
+        />
+      </Theme>,
+    );
+
+    const cell = document.querySelector('[data-grid-cell]');
+    expect(cell).not.toBeNull();
+    expect(cell).toHaveAttribute('data-state', 'closed');
+
+    fireEvent.contextMenu(cell as HTMLElement);
+
+    expect(
+      await screen.findByRole('menuitem', { name: 'New activity' }),
+    ).toBeVisible();
+  });
+});

--- a/src/Trip/TripTimetableView/TimetableDragTarget.tsx
+++ b/src/Trip/TripTimetableView/TimetableDragTarget.tsx
@@ -1,0 +1,93 @@
+import { ContextMenu } from '@radix-ui/themes';
+import type { CSSProperties, MouseEvent, RefObject } from 'react';
+import { memo, useRef } from 'react';
+import { TimetableCell } from './TimetableCell';
+import { useInViewport } from './useInViewport';
+
+interface TimetableDragTargetProps {
+  day: number;
+  timeStr: string;
+  columnStr: string;
+  gridStyle: CSSProperties;
+  scrollContainerRef: RefObject<HTMLElement | null>;
+  tripTitle?: string;
+  userCanModifyTrip: boolean;
+  onNewActivity: (e: MouseEvent<HTMLDivElement>) => void;
+  onNewFlight: (e: MouseEvent<HTMLDivElement>) => void;
+  onNewTrain: (e: MouseEvent<HTMLDivElement>) => void;
+  onNewAccommodation: (e: MouseEvent<HTMLDivElement>) => void;
+  onNewMacroplan: (e: MouseEvent<HTMLDivElement>) => void;
+}
+
+function TimetableDragTargetInner({
+  day,
+  timeStr,
+  columnStr,
+  gridStyle,
+  scrollContainerRef,
+  tripTitle,
+  userCanModifyTrip,
+  onNewActivity,
+  onNewFlight,
+  onNewTrain,
+  onNewAccommodation,
+  onNewMacroplan,
+}: TimetableDragTargetProps) {
+  const placeholderRef = useRef<HTMLDivElement>(null);
+  const isInViewport = useInViewport(placeholderRef, scrollContainerRef);
+
+  return (
+    <div ref={placeholderRef} style={gridStyle}>
+      {isInViewport ? (
+        <ContextMenu.Root>
+          <ContextMenu.Trigger>
+            <TimetableCell row={`t${timeStr}`} column={columnStr} />
+          </ContextMenu.Trigger>
+          <ContextMenu.Content>
+            <ContextMenu.Label>{tripTitle}</ContextMenu.Label>
+            <ContextMenu.Item
+              onClick={userCanModifyTrip ? onNewActivity : undefined}
+              disabled={!userCanModifyTrip}
+              data-time-start={timeStr}
+              data-day={day}
+            >
+              New activity
+            </ContextMenu.Item>
+            <ContextMenu.Item
+              onClick={userCanModifyTrip ? onNewFlight : undefined}
+              disabled={!userCanModifyTrip}
+              data-time-start={timeStr}
+              data-day={day}
+            >
+              New flight
+            </ContextMenu.Item>
+            <ContextMenu.Item
+              onClick={userCanModifyTrip ? onNewTrain : undefined}
+              disabled={!userCanModifyTrip}
+              data-time-start={timeStr}
+              data-day={day}
+            >
+              New train
+            </ContextMenu.Item>
+            <ContextMenu.Item
+              onClick={userCanModifyTrip ? onNewAccommodation : undefined}
+              disabled={!userCanModifyTrip}
+              data-day={day}
+            >
+              New accommodation
+            </ContextMenu.Item>
+            <ContextMenu.Item
+              onClick={userCanModifyTrip ? onNewMacroplan : undefined}
+              disabled={!userCanModifyTrip}
+              data-day={day}
+            >
+              New day plan
+            </ContextMenu.Item>
+          </ContextMenu.Content>
+        </ContextMenu.Root>
+      ) : null}
+    </div>
+  );
+}
+
+export const TimetableDragTarget = memo(TimetableDragTargetInner);

--- a/src/Trip/TripTimetableView/TimetableGrid.tsx
+++ b/src/Trip/TripTimetableView/TimetableGrid.tsx
@@ -1,4 +1,4 @@
-import { ContextMenu } from '@radix-ui/themes';
+import type { RefObject } from 'react';
 import React, { type MouseEvent, memo, useCallback, useMemo } from 'react';
 import { AccommodationNewDialog } from '../../Accommodation/AccommodationNewDialog';
 import { ActivityNewDialog } from '../../Activity/ActivityNewDialog';
@@ -8,14 +8,15 @@ import { useBoundStore } from '../../data/store';
 import { MacroplanNewDialog } from '../../Macroplan/MacroplanNewDialog';
 import { TripUserRole } from '../../User/TripUserRole';
 import { useCurrentTrip } from '../store/hooks';
-import { TimetableCell } from './TimetableCell';
+import { TimetableDragTarget } from './TimetableDragTarget';
 import { pad2 } from './time';
 
 interface TimetableGridProps {
   days: number;
+  scrollContainerRef: RefObject<HTMLElement | null>;
 }
 
-function TimetableGridInner({ days }: TimetableGridProps) {
+function TimetableGridInner({ days, scrollContainerRef }: TimetableGridProps) {
   // Create an array of hours (0-23)
   const hours = Array.from({ length: 24 }, (_, i) => i);
 
@@ -136,80 +137,29 @@ function TimetableGridInner({ days }: TimetableGridProps) {
                 const columnStr = `d${day}-c1`; // Assuming single column per day
 
                 return (
-                  <ContextMenu.Root key={`${day}-${timeStr}`}>
-                    <ContextMenu.Trigger>
-                      <div
-                        style={{
-                          gridRowStart: `t${timeStr}`,
-                          gridRowEnd:
-                            minute === 30
-                              ? `te${pad2(hour)}59`
-                              : `te${pad2(hour)}30`,
-                          gridColumnStart: `d${day}`,
-                          gridColumnEnd: `de${day}`,
-                        }}
-                      >
-                        <TimetableCell row={`t${timeStr}`} column={columnStr} />
-                      </div>
-                    </ContextMenu.Trigger>
-                    <ContextMenu.Content>
-                      <ContextMenu.Label>{trip?.title}</ContextMenu.Label>
-                      <ContextMenu.Item
-                        onClick={
-                          userCanModifyTrip ? openActivityNewDialog : undefined
-                        }
-                        disabled={!userCanModifyTrip}
-                        data-time-start={timeStr}
-                        data-day={day}
-                      >
-                        New activity
-                      </ContextMenu.Item>
-
-                      <ContextMenu.Item
-                        onClick={
-                          userCanModifyTrip ? openFlightNewDialog : undefined
-                        }
-                        disabled={!userCanModifyTrip}
-                        data-time-start={timeStr}
-                        data-day={day}
-                      >
-                        New flight
-                      </ContextMenu.Item>
-
-                      <ContextMenu.Item
-                        onClick={
-                          userCanModifyTrip ? openTrainNewDialog : undefined
-                        }
-                        disabled={!userCanModifyTrip}
-                        data-time-start={timeStr}
-                        data-day={day}
-                      >
-                        New train
-                      </ContextMenu.Item>
-
-                      <ContextMenu.Item
-                        onClick={
-                          userCanModifyTrip
-                            ? openAccommodationNewDialog
-                            : undefined
-                        }
-                        disabled={!userCanModifyTrip}
-                        data-day={day}
-                      >
-                        New acommodation
-                      </ContextMenu.Item>
-
-                      <ContextMenu.Item
-                        onClick={
-                          userCanModifyTrip ? openMacroplanNewDialog : undefined
-                        }
-                        disabled={!userCanModifyTrip}
-                        data-day={day}
-                      >
-                        New day plan
-                      </ContextMenu.Item>
-                    </ContextMenu.Content>
-                  </ContextMenu.Root>
+                  <TimetableDragTarget
+                    key={`${day}-${timeStr}`}
+                    day={day}
+                    timeStr={timeStr}
+                    columnStr={columnStr}
+                    gridStyle={{
+                      gridRowStart: `t${timeStr}`,
+                      gridRowEnd:
+                        minute === 30
+                          ? `te${pad2(hour)}59`
+                          : `te${pad2(hour)}30`,
+                      gridColumnStart: `d${day}`,
+                      gridColumnEnd: `de${day}`,
+                    }}
+                    scrollContainerRef={scrollContainerRef}
+                    tripTitle={trip?.title}
+                    userCanModifyTrip={userCanModifyTrip}
+                    onNewActivity={openActivityNewDialog}
+                    onNewFlight={openFlightNewDialog}
+                    onNewTrain={openTrainNewDialog}
+                    onNewAccommodation={openAccommodationNewDialog}
+                    onNewMacroplan={openMacroplanNewDialog}
+                  />
                 );
               })}
             </React.Fragment>
@@ -222,6 +172,9 @@ function TimetableGridInner({ days }: TimetableGridProps) {
 export const TimetableGrid = memo(
   TimetableGridInner,
   (prevProps, nextProps) => {
-    return prevProps.days === nextProps.days;
+    return (
+      prevProps.days === nextProps.days &&
+      prevProps.scrollContainerRef === nextProps.scrollContainerRef
+    );
   },
 );

--- a/src/Trip/TripTimetableView/useInViewport.test.tsx
+++ b/src/Trip/TripTimetableView/useInViewport.test.tsx
@@ -1,0 +1,74 @@
+import { act, render, screen } from '@testing-library/react';
+import { useRef } from 'react';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { useInViewport } from './useInViewport';
+
+class MockIntersectionObserver {
+  static instances: MockIntersectionObserver[] = [];
+
+  readonly observe = vi.fn();
+  readonly unobserve = vi.fn();
+  readonly disconnect = vi.fn();
+
+  constructor(
+    readonly callback: IntersectionObserverCallback,
+    readonly options?: IntersectionObserverInit,
+  ) {
+    MockIntersectionObserver.instances.push(this);
+  }
+}
+
+function ViewportTargets() {
+  const rootRef = useRef<HTMLDivElement>(null);
+  const firstRef = useRef<HTMLDivElement>(null);
+  const secondRef = useRef<HTMLDivElement>(null);
+  const firstIsInViewport = useInViewport(firstRef, rootRef);
+  const secondIsInViewport = useInViewport(secondRef, rootRef);
+
+  return (
+    <div ref={rootRef}>
+      <div ref={firstRef} data-testid="first">
+        {String(firstIsInViewport)}
+      </div>
+      <div ref={secondRef} data-testid="second">
+        {String(secondIsInViewport)}
+      </div>
+    </div>
+  );
+}
+
+describe('useInViewport', () => {
+  beforeEach(() => {
+    MockIntersectionObserver.instances = [];
+    vi.stubGlobal('IntersectionObserver', MockIntersectionObserver);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  test('shares an observer while updating each observed target independently', () => {
+    render(<ViewportTargets />);
+
+    expect(MockIntersectionObserver.instances).toHaveLength(1);
+
+    const observer = MockIntersectionObserver.instances[0];
+    const first = screen.getByTestId('first');
+    const second = screen.getByTestId('second');
+
+    act(() => {
+      observer.callback(
+        [
+          {
+            isIntersecting: true,
+            target: second,
+          } as unknown as IntersectionObserverEntry,
+        ],
+        observer as never,
+      );
+    });
+
+    expect(first).toHaveTextContent('false');
+    expect(second).toHaveTextContent('true');
+  });
+});

--- a/src/Trip/TripTimetableView/useInViewport.ts
+++ b/src/Trip/TripTimetableView/useInViewport.ts
@@ -1,6 +1,20 @@
 import { type RefObject, useEffect, useState } from 'react';
 
 /**
+ * Key: root
+ * Value: Map<rootMargin, cached observer and target callbacks>
+ */
+const rootToMap = new WeakMap<
+  RefObject<HTMLElement | null>,
+  Map<string, CachedObserver>
+>();
+
+interface CachedObserver {
+  observer: IntersectionObserver;
+  targetToCallback: Map<Element, (isInViewport: boolean) => void>;
+}
+
+/**
  * Reports whether `ref`'s element intersects (or is within `rootMargin` of)
  * the given scroll container. Used to lazily mount heavy DOM (e.g. the
  * timetable drag targets) so long trips don't render every cell up front.
@@ -16,17 +30,34 @@ export function useInViewport(
     const target = ref.current;
     if (!target) return;
 
-    const observer = new IntersectionObserver(
-      (entries) => {
-        for (const entry of entries) {
-          setIsInViewport(entry.isIntersecting);
-        }
-      },
-      { root: root.current, rootMargin },
-    );
+    const rootMarginToObserverMap = rootToMap.get(root) ?? new Map();
+    let cachedObserver = rootMarginToObserverMap.get(rootMargin);
 
-    observer.observe(target);
-    return () => observer.disconnect();
+    if (!cachedObserver) {
+      const targetToCallback = new Map<
+        Element,
+        (isInViewport: boolean) => void
+      >();
+      const observer = new IntersectionObserver(
+        (entries) => {
+          for (const entry of entries) {
+            targetToCallback.get(entry.target)?.(entry.isIntersecting);
+          }
+        },
+        { root: root.current, rootMargin },
+      );
+      cachedObserver = { observer, targetToCallback };
+      rootMarginToObserverMap.set(rootMargin, cachedObserver);
+      rootToMap.set(root, rootMarginToObserverMap);
+    }
+
+    cachedObserver.targetToCallback.set(target, setIsInViewport);
+    cachedObserver.observer.observe(target);
+
+    return () => {
+      cachedObserver.targetToCallback.delete(target);
+      cachedObserver.observer.unobserve(target);
+    };
   }, [ref, root, rootMargin]);
 
   return isInViewport;

--- a/src/Trip/TripTimetableView/useInViewport.ts
+++ b/src/Trip/TripTimetableView/useInViewport.ts
@@ -1,0 +1,33 @@
+import { type RefObject, useEffect, useState } from 'react';
+
+/**
+ * Reports whether `ref`'s element intersects (or is within `rootMargin` of)
+ * the given scroll container. Used to lazily mount heavy DOM (e.g. the
+ * timetable drag targets) so long trips don't render every cell up front.
+ */
+export function useInViewport(
+  ref: RefObject<HTMLElement | null>,
+  root: RefObject<HTMLElement | null>,
+  rootMargin = '400px',
+): boolean {
+  const [isInViewport, setIsInViewport] = useState(false);
+
+  useEffect(() => {
+    const target = ref.current;
+    if (!target) return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          setIsInViewport(entry.isIntersecting);
+        }
+      },
+      { root: root.current, rootMargin },
+    );
+
+    observer.observe(target);
+    return () => observer.disconnect();
+  }, [ref, root, rootMargin]);
+
+  return isInViewport;
+}


### PR DESCRIPTION
Use an IntersectionObserver so the heavy ContextMenu/TimetableCell drag targets are only rendered for cells in or near the scroll container's viewport, reducing DOM node count for long trips. Off-screen cells render a lightweight placeholder to preserve the CSS grid layout.