### PR TITLE
feat: swap whole day's activities to another day

### DIFF
--- a/src/Trip/TripTimetableView/SwapDay/SwapDayDialog.tsx
+++ b/src/Trip/TripTimetableView/SwapDay/SwapDayDialog.tsx
@@ -1,0 +1,187 @@
+import { Button, Dialog, Flex, Select, Spinner, Text } from '@radix-ui/themes';
+import { useCallback, useState } from 'react';
+import { toFormat } from '../../../common/dateTime/temporalFormatter';
+import { dangerToken } from '../../../common/ui';
+import { useBoundStore } from '../../../data/store';
+import type { TripSliceActivity, TripSliceTrip } from '../../store/types';
+import { dbSwapDayActivities } from './dbSwapDay';
+
+export function SwapDayDialog({
+  trip,
+  activities,
+  sourceDayIndex,
+  days,
+}: {
+  trip: TripSliceTrip;
+  activities: TripSliceActivity[];
+  sourceDayIndex: number;
+  days: Array<{ dayIndex: number; startMs: number }>;
+}) {
+  const popDialog = useBoundStore((state) => state.popDialog);
+  const publishToast = useBoundStore((state) => state.publishToast);
+  const resetToast = useBoundStore((state) => state.resetToast);
+
+  const targetDays = days.filter((day) => day.dayIndex !== sourceDayIndex);
+  const [selectedDayIndex, setSelectedDayIndex] = useState<string>(
+    String(targetDays[0]?.dayIndex ?? ''),
+  );
+  const [isSwapping, setIsSwapping] = useState(false);
+  const [error, setError] = useState<string | undefined>(undefined);
+
+  const sourceDay = days.find((day) => day.dayIndex === sourceDayIndex);
+
+  const dayLabel = useCallback(
+    (dayIndex: number): string => {
+      const day = days.find((d) => d.dayIndex === dayIndex);
+      if (!day) return `Day ${dayIndex + 1}`;
+      const dateTime = Temporal.Instant.fromEpochMilliseconds(
+        day.startMs,
+      ).toZonedDateTimeISO(trip.timeZone);
+      return `Day ${dayIndex + 1} — ${toFormat('ccc, d LLL yyyy', dateTime)}`;
+    },
+    [days, trip.timeZone],
+  );
+
+  const handleSwap = useCallback(async () => {
+    if (selectedDayIndex === '') return;
+    const targetDay = days.find(
+      (d) => d.dayIndex === Number.parseInt(selectedDayIndex, 10),
+    );
+    if (!targetDay || !sourceDay || targetDay.dayIndex === sourceDay.dayIndex) {
+      return;
+    }
+
+    setIsSwapping(true);
+    setError(undefined);
+    try {
+      const { movedCount, undo } = await dbSwapDayActivities({
+        activities,
+        sourceDayStartMs: sourceDay.startMs,
+        targetDayStartMs: targetDay.startMs,
+        timeZone: trip.timeZone,
+      });
+
+      const sourceLabel = dayLabel(sourceDay.dayIndex);
+      const targetLabel = dayLabel(targetDay.dayIndex);
+      popDialog();
+      resetToast();
+      publishToast({
+        root: { duration: 15_000 },
+        title: {
+          children:
+            movedCount > 0
+              ? `Swapped activities from ${sourceLabel} to ${targetLabel}`
+              : `No activities to swap on ${sourceLabel}`,
+        },
+        action:
+          movedCount > 0
+            ? {
+                children: 'Undo',
+                altText: `Undo the swap of ${sourceLabel} and ${targetLabel}`,
+                onClick: async () => {
+                  await undo();
+                  resetToast();
+                  publishToast({
+                    root: {},
+                    title: { children: `Undone swap of ${sourceLabel}` },
+                    close: {},
+                  });
+                },
+              }
+            : undefined,
+        close: {},
+      });
+    } catch (e) {
+      console.error('Failed to swap day activities', e);
+      setError(
+        typeof e === 'string' && e
+          ? e
+          : 'Failed to swap activities. Please try again.',
+      );
+      setIsSwapping(false);
+    }
+  }, [
+    activities,
+    days,
+    dayLabel,
+    popDialog,
+    publishToast,
+    resetToast,
+    selectedDayIndex,
+    sourceDay,
+    trip.timeZone,
+  ]);
+
+  return (
+    <Dialog.Root open onOpenChange={popDialog}>
+      <Dialog.Content
+        maxWidth="480px"
+        onEscapeKeyDown={popDialog}
+        onInteractOutside={popDialog}
+      >
+        <Dialog.Title>Swap activities to another day</Dialog.Title>
+        <Dialog.Description size="2">
+          {sourceDay
+            ? `Move all activities from ${dayLabel(sourceDay.dayIndex)} to another day. Activities already on the target day will be moved to ${dayLabel(sourceDay.dayIndex)} in exchange.`
+            : 'Pick which day to swap.'}
+        </Dialog.Description>
+
+        <Flex direction="column" gap="3" mt="4">
+          <Flex direction="column" gap="1">
+            <Text as="label" size="2" weight="medium">
+              Swap {sourceDay ? dayLabel(sourceDay.dayIndex) : 'this day'} with
+            </Text>
+            <Select.Root
+              value={selectedDayIndex}
+              onValueChange={(value) => {
+                setSelectedDayIndex(value);
+                setError(undefined);
+              }}
+              size="2"
+              disabled={isSwapping}
+            >
+              <Select.Trigger />
+              <Select.Content>
+                {targetDays.map((day) => {
+                  return (
+                    <Select.Item
+                      key={day.dayIndex}
+                      value={String(day.dayIndex)}
+                    >
+                      {dayLabel(day.dayIndex)}
+                    </Select.Item>
+                  );
+                })}
+              </Select.Content>
+            </Select.Root>
+          </Flex>
+
+          {error ? (
+            <Text color={dangerToken} size="2">
+              {error}
+            </Text>
+          ) : null}
+        </Flex>
+
+        <Flex gap="3" mt="4" justify="end">
+          <Button
+            variant="soft"
+            color="gray"
+            disabled={isSwapping}
+            onClick={popDialog}
+          >
+            Cancel
+          </Button>
+          <Button
+            variant="solid"
+            disabled={selectedDayIndex === '' || isSwapping}
+            onClick={handleSwap}
+          >
+            {isSwapping ? <Spinner size="1" /> : null}
+            Swap day
+          </Button>
+        </Flex>
+      </Dialog.Content>
+    </Dialog.Root>
+  );
+}

--- a/src/Trip/TripTimetableView/SwapDay/SwapDayDialog.tsx
+++ b/src/Trip/TripTimetableView/SwapDay/SwapDayDialog.tsx
@@ -70,8 +70,8 @@ export function SwapDayDialog({
         title: {
           children:
             movedCount > 0
-              ? `Swapped activities from ${sourceLabel} to ${targetLabel}`
-              : `No activities to swap on ${sourceLabel}`,
+              ? `Swapped ${sourceLabel} and ${targetLabel}`
+              : `No activities to swap on ${sourceLabel} or ${targetLabel}`,
         },
         action:
           movedCount > 0
@@ -83,7 +83,9 @@ export function SwapDayDialog({
                   resetToast();
                   publishToast({
                     root: {},
-                    title: { children: `Undone swap of ${sourceLabel}` },
+                    title: {
+                      children: `Undone swap of ${sourceLabel} and ${targetLabel}`,
+                    },
                     close: {},
                   });
                 },
@@ -113,7 +115,7 @@ export function SwapDayDialog({
   ]);
 
   return (
-    <Dialog.Root open onOpenChange={popDialog}>
+    <Dialog.Root open>
       <Dialog.Content
         maxWidth="480px"
         onEscapeKeyDown={popDialog}

--- a/src/Trip/TripTimetableView/SwapDay/SwapDayDialog.tsx
+++ b/src/Trip/TripTimetableView/SwapDay/SwapDayDialog.tsx
@@ -37,7 +37,7 @@ export function SwapDayDialog({
       const dateTime = Temporal.Instant.fromEpochMilliseconds(
         day.startMs,
       ).toZonedDateTimeISO(trip.timeZone);
-      return `Day ${dayIndex + 1} — ${toFormat('ccc, d LLL yyyy', dateTime)}`;
+      return `Day ${dayIndex + 1} (${toFormat('ccc, d LLL yyyy', dateTime)})`;
     },
     [days, trip.timeZone],
   );
@@ -119,7 +119,7 @@ export function SwapDayDialog({
         onEscapeKeyDown={popDialog}
         onInteractOutside={popDialog}
       >
-        <Dialog.Title>Swap activities to another day</Dialog.Title>
+        <Dialog.Title>Swap Activities to Another Day</Dialog.Title>
         <Dialog.Description size="2">
           {sourceDay
             ? `Move all activities from ${dayLabel(sourceDay.dayIndex)} to another day. Activities already on the target day will be moved to ${dayLabel(sourceDay.dayIndex)} in exchange.`

--- a/src/Trip/TripTimetableView/SwapDay/dbSwapDay.ts
+++ b/src/Trip/TripTimetableView/SwapDay/dbSwapDay.ts
@@ -1,0 +1,70 @@
+import { db } from '../../../data/db';
+import type { TripSliceActivity } from '../../store/types';
+import { computeSwapDayActivityUpdates } from './swapDay';
+
+/**
+ * Swap all activities between two days.
+ *
+ * `sourceDayStartMs` and `targetDayStartMs` are the epoch milliseconds of the
+ * start of each day (in the trip's time zone). Returns an `undo` function that
+ * restores the original timestamps so callers can offer an "Undo" action.
+ */
+export async function dbSwapDayActivities({
+  activities,
+  sourceDayStartMs,
+  targetDayStartMs,
+  timeZone,
+}: {
+  activities: TripSliceActivity[];
+  sourceDayStartMs: number;
+  targetDayStartMs: number;
+  timeZone: string;
+}): Promise<{
+  movedCount: number;
+  undo: () => Promise<void>;
+}> {
+  const updates = computeSwapDayActivityUpdates({
+    activities,
+    sourceDayStartMs,
+    targetDayStartMs,
+    timeZone,
+  });
+
+  if (updates.length === 0) {
+    return {
+      movedCount: 0,
+      undo: async () => {},
+    };
+  }
+
+  // Keep a snapshot of the original timestamps for undo.
+  const originalById = new Map(
+    activities.map((activity) => [activity.id, activity]),
+  );
+
+  await db.transact(
+    updates.map((update) => {
+      return db.tx.activity[update.id].merge({
+        timestampStart: update.timestampStart,
+        timestampEnd: update.timestampEnd,
+        lastUpdatedAt: Date.now(),
+      });
+    }),
+  );
+
+  return {
+    movedCount: updates.length,
+    undo: async () => {
+      await db.transact(
+        updates.map((update) => {
+          const original = originalById.get(update.id);
+          return db.tx.activity[update.id].merge({
+            timestampStart: original?.timestampStart,
+            timestampEnd: original?.timestampEnd,
+            lastUpdatedAt: Date.now(),
+          });
+        }),
+      );
+    },
+  };
+}

--- a/src/Trip/TripTimetableView/SwapDay/swapDay.test.ts
+++ b/src/Trip/TripTimetableView/SwapDay/swapDay.test.ts
@@ -148,4 +148,49 @@ describe('computeSwapDayActivityUpdates', () => {
     // Shifting a day onto itself yields identical timestamps, so no updates
     expect(updates).toHaveLength(0);
   });
+
+  test('spans travel as a whole with the day they start on', () => {
+    // An activity starting on Day 3 at 22:00 and ending on Day 4 at 04:00
+    // (spans the day boundary).
+    const spanning = activity('a-span', 2026, 3, 3, 22, 6 * 60 * 60 * 1000);
+
+    const updates = computeSwapDayActivityUpdates({
+      activities: [spanning],
+      sourceDayStartMs,
+      targetDayStartMs,
+      timeZone: TZ,
+    });
+
+    // Exactly one update: it belongs to Day 3 (its start date), never twice.
+    expect(updates).toHaveLength(1);
+    const update = updates[0];
+    expect(update.id).toBe('a-span');
+
+    // Whole activity relocates to Day 8 at the same wall-clock time,
+    // ending on Day 9. Duration is preserved.
+    expect(localTimeOf(update.timestampStart ?? 0)).toEqual([
+      2026, 3, 8, 22, 0,
+    ]);
+    expect(localTimeOf(update.timestampEnd ?? 0)).toEqual([2026, 3, 9, 4, 0]);
+    expect((update.timestampEnd ?? 0) - (update.timestampStart ?? 0)).toBe(
+      6 * 60 * 60 * 1000,
+    );
+  });
+
+  test('a spanning activity is not moved when swapping the day it ends on', () => {
+    // Same Day 3 -> Day 4 spanning activity; its end date is Day 4.
+    const spanning = activity('a-span', 2026, 3, 3, 22, 6 * 60 * 60 * 1000);
+    const dayFourStartMs = dayStart(2026, 3, 4);
+
+    // Swapping Day 4 (where the activity ends) with Day 8 must NOT move it,
+    // since it is only a member of its start day (Day 3).
+    const updates = computeSwapDayActivityUpdates({
+      activities: [spanning],
+      sourceDayStartMs: dayFourStartMs,
+      targetDayStartMs,
+      timeZone: TZ,
+    });
+
+    expect(updates).toHaveLength(0);
+  });
 });

--- a/src/Trip/TripTimetableView/SwapDay/swapDay.test.ts
+++ b/src/Trip/TripTimetableView/SwapDay/swapDay.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, test } from 'vitest';
+import type { TripSliceActivity } from '../../store/types';
+import { computeSwapDayActivityUpdates } from './swapDay';
+
+const TZ = 'America/New_York';
+
+function dayStart(year: number, month: number, day: number): number {
+  return Temporal.ZonedDateTime.from({
+    timeZone: TZ,
+    year,
+    month,
+    day,
+    hour: 0,
+  })
+    .startOfDay()
+    .toInstant().epochMilliseconds;
+}
+
+function activity(
+  id: string,
+  startYear: number,
+  startMonth: number,
+  startDay: number,
+  startHour: number,
+  durationMs: number,
+): TripSliceActivity {
+  const startMs = Temporal.ZonedDateTime.from({
+    timeZone: TZ,
+    year: startYear,
+    month: startMonth,
+    day: startDay,
+    hour: startHour,
+  }).toInstant().epochMilliseconds;
+  return {
+    id,
+    title: id,
+    description: '',
+    location: '',
+    locationLat: undefined,
+    locationLng: undefined,
+    locationZoom: undefined,
+    locationDestination: undefined,
+    locationDestinationLat: undefined,
+    locationDestinationLng: undefined,
+    locationDestinationZoom: undefined,
+    timestampStart: startMs,
+    timestampEnd: startMs + durationMs,
+    timeZoneStart: TZ,
+    timeZoneEnd: TZ,
+    createdAt: 0,
+    lastUpdatedAt: 0,
+    flags: undefined,
+    icon: undefined,
+    tripId: 'trip1',
+    commentGroupId: undefined,
+  };
+}
+
+function localTimeOf(
+  epochMs: number,
+): [number, number, number, number, number] {
+  const d =
+    Temporal.Instant.fromEpochMilliseconds(epochMs).toZonedDateTimeISO(TZ);
+  return [d.year, d.month, d.day, d.hour, d.minute];
+}
+
+describe('computeSwapDayActivityUpdates', () => {
+  const sourceDayStartMs = dayStart(2026, 3, 3); // Day 3
+  const targetDayStartMs = dayStart(2026, 3, 8); // Day 8
+
+  test('swaps activities between the two days, preserving time of day', () => {
+    const activities = [
+      activity('a-source', 2026, 3, 3, 10, 60 * 60 * 1000),
+      activity('a-target', 2026, 3, 8, 14, 2 * 60 * 60 * 1000),
+      activity('a-other', 2026, 3, 5, 9, 60 * 60 * 1000),
+    ];
+
+    const updates = computeSwapDayActivityUpdates({
+      activities,
+      sourceDayStartMs,
+      targetDayStartMs,
+      timeZone: TZ,
+    });
+
+    expect(updates).toHaveLength(2);
+
+    const sourceUpdate = updates.find((u) => u.id === 'a-source');
+    // 10:00 on Day 3 should land at 10:00 on Day 8
+    expect(localTimeOf(sourceUpdate?.timestampStart ?? 0)).toEqual([
+      2026, 3, 8, 10, 0,
+    ]);
+    // Duration preserved (1 hour)
+    expect(
+      (sourceUpdate?.timestampEnd ?? 0) - (sourceUpdate?.timestampStart ?? 0),
+    ).toBe(60 * 60 * 1000);
+
+    const targetUpdate = updates.find((u) => u.id === 'a-target');
+    // 14:00 on Day 8 should land at 14:00 on Day 3
+    expect(localTimeOf(targetUpdate?.timestampStart ?? 0)).toEqual([
+      2026, 3, 3, 14, 0,
+    ]);
+    expect(
+      (targetUpdate?.timestampEnd ?? 0) - (targetUpdate?.timestampStart ?? 0),
+    ).toBe(2 * 60 * 60 * 1000);
+
+    // Activities on other days are untouched
+    expect(updates.find((u) => u.id === 'a-other')).toBeUndefined();
+  });
+
+  test('leaves activities without a start time alone', () => {
+    const noTime: TripSliceActivity = activity('a-null', 2026, 3, 3, 10, 0);
+    noTime.timestampStart = null;
+    noTime.timestampEnd = null;
+
+    const updates = computeSwapDayActivityUpdates({
+      activities: [noTime],
+      sourceDayStartMs,
+      targetDayStartMs,
+      timeZone: TZ,
+    });
+
+    expect(updates).toHaveLength(0);
+  });
+
+  test('returns empty when there is nothing to move', () => {
+    const activities = [activity('a-other', 2026, 3, 5, 9, 60 * 60 * 1000)];
+
+    const updates = computeSwapDayActivityUpdates({
+      activities,
+      sourceDayStartMs,
+      targetDayStartMs,
+      timeZone: TZ,
+    });
+
+    expect(updates).toHaveLength(0);
+  });
+
+  test('is a no-op when both days are the same', () => {
+    const activities = [activity('a-source', 2026, 3, 3, 10, 60 * 60 * 1000)];
+
+    const updates = computeSwapDayActivityUpdates({
+      activities,
+      sourceDayStartMs,
+      targetDayStartMs: sourceDayStartMs,
+      timeZone: TZ,
+    });
+
+    // Shifting a day onto itself yields identical timestamps, so no updates
+    expect(updates).toHaveLength(0);
+  });
+});

--- a/src/Trip/TripTimetableView/SwapDay/swapDay.ts
+++ b/src/Trip/TripTimetableView/SwapDay/swapDay.ts
@@ -1,0 +1,107 @@
+import { shiftTimestampToTripDate } from '../../duplicateTripDateShift';
+import type { TripSliceActivity } from '../../store/types';
+
+/** A single activity's timestamps after a day swap (id + new values). */
+export type SwapDayActivityUpdate = {
+  id: string;
+  timestampStart: number | null | undefined;
+  timestampEnd: number | null | undefined;
+};
+
+function dayDateFromStartMs(
+  startMs: number,
+  timeZone: string,
+): Temporal.PlainDate {
+  return Temporal.Instant.fromEpochMilliseconds(startMs)
+    .toZonedDateTimeISO(timeZone)
+    .startOfDay()
+    .toPlainDate();
+}
+
+/**
+ * Compute the activity timestamp updates needed to swap two days.
+ *
+ * An activity is considered to "belong" to a day when its wall-clock start
+ * date (in the trip's time zone) is that day. Activities scheduled on the
+ * source day are shifted to the target day (and vice versa), preserving each
+ * activity's wall-clock time and duration via calendar-day arithmetic so that
+ * DST transitions don't drift the times.
+ *
+ * Only activities that actually move are returned.
+ */
+export function computeSwapDayActivityUpdates({
+  activities,
+  sourceDayStartMs,
+  targetDayStartMs,
+  timeZone,
+}: {
+  activities: TripSliceActivity[];
+  sourceDayStartMs: number;
+  targetDayStartMs: number;
+  timeZone: string;
+}): SwapDayActivityUpdate[] {
+  const sourceDate = dayDateFromStartMs(sourceDayStartMs, timeZone);
+  const targetDate = dayDateFromStartMs(targetDayStartMs, timeZone);
+
+  const updates: SwapDayActivityUpdate[] = [];
+
+  for (const activity of activities) {
+    const startMs = activity.timestampStart;
+    if (startMs == null) {
+      continue;
+    }
+
+    const activityDate = Temporal.Instant.fromEpochMilliseconds(startMs)
+      .toZonedDateTimeISO(timeZone)
+      .toPlainDate();
+
+    let newStartMs: number | null | undefined;
+    let newEndMs: number | null | undefined;
+
+    if (activityDate.equals(sourceDate)) {
+      newStartMs = shiftTimestampToTripDate(
+        startMs,
+        sourceDayStartMs,
+        targetDayStartMs,
+        timeZone,
+      );
+      newEndMs =
+        activity.timestampEnd != null
+          ? shiftTimestampToTripDate(
+              activity.timestampEnd,
+              sourceDayStartMs,
+              targetDayStartMs,
+              timeZone,
+            )
+          : activity.timestampEnd;
+    } else if (activityDate.equals(targetDate)) {
+      newStartMs = shiftTimestampToTripDate(
+        startMs,
+        targetDayStartMs,
+        sourceDayStartMs,
+        timeZone,
+      );
+      newEndMs =
+        activity.timestampEnd != null
+          ? shiftTimestampToTripDate(
+              activity.timestampEnd,
+              targetDayStartMs,
+              sourceDayStartMs,
+              timeZone,
+            )
+          : activity.timestampEnd;
+    } else {
+      continue;
+    }
+
+    if (newStartMs !== startMs || newEndMs !== activity.timestampEnd) {
+      updates.push({
+        id: activity.id,
+        timestampStart: newStartMs,
+        timestampEnd: newEndMs,
+      });
+    }
+  }
+
+  return updates;
+}

--- a/src/Trip/TripTimetableView/Timetable.tsx
+++ b/src/Trip/TripTimetableView/Timetable.tsx
@@ -60,7 +60,7 @@ import {
   useTripMacroplans,
   useTripTimetableDragging,
 } from '../store/hooks';
-import type { TripSliceTrip } from '../store/types';
+import type { TripSliceActivity, TripSliceTrip } from '../store/types';
 import { TripViewMode } from '../TripViewMode';
 import {
   generateAccommodationGridTemplateColumns,
@@ -295,6 +295,11 @@ export function Timetable() {
       trip?.currentUserRole === TripUserRole.Editor
     );
   }, [trip?.currentUserRole]);
+
+  // Days available for the day-swap context menu (derived once, not per header).
+  const tripDays = useMemo(() => {
+    return trip ? dayGroupsFromTrip(trip) : [];
+  }, [trip]);
 
   // Handle dropping activities on the timetable
   const handleDrop = useCallback(
@@ -559,6 +564,9 @@ export function Timetable() {
               isActive={isCurrentDay}
               dayIndex={i}
               userCanModifyTrip={userCanModifyTrip}
+              trip={trip}
+              activities={activities}
+              tripDays={tripDays}
             />
           );
         })}
@@ -724,6 +732,9 @@ function TimetableDayHeaderInner({
   isActive,
   dayIndex,
   userCanModifyTrip,
+  trip,
+  activities,
+  tripDays,
 }: {
   dateString: string;
   gridColumnStart: string;
@@ -731,9 +742,10 @@ function TimetableDayHeaderInner({
   isActive?: boolean;
   dayIndex: number;
   userCanModifyTrip: boolean;
+  trip: TripSliceTrip | undefined;
+  activities: TripSliceActivity[];
+  tripDays: Array<{ dayIndex: number; startMs: number }>;
 }) {
-  const { trip } = useCurrentTrip();
-  const activities = useTripActivities(trip?.activityIds ?? []);
   const pushDialog = useBoundStore((state) => state.pushDialog);
 
   const style = useMemo(() => {
@@ -744,17 +756,16 @@ function TimetableDayHeaderInner({
   }, [gridColumnStart, gridColumnEnd]);
 
   const handleSwapDay = useCallback(() => {
-    if (!trip) return;
-    const days = dayGroupsFromTrip(trip);
-    const sourceDay = days.find((day) => day.dayIndex === dayIndex);
+    if (!trip || tripDays.length < 2) return;
+    const sourceDay = tripDays.find((day) => day.dayIndex === dayIndex);
     if (!sourceDay) return;
     pushDialog(SwapDayDialog, {
       trip,
       activities,
       sourceDayIndex: dayIndex,
-      days,
+      days: tripDays,
     });
-  }, [activities, dayIndex, pushDialog, trip]);
+  }, [activities, dayIndex, pushDialog, trip, tripDays]);
 
   const header = (
     <Text
@@ -775,13 +786,15 @@ function TimetableDayHeaderInner({
     return header;
   }
 
+  const canSwap = tripDays.length >= 2;
+
   return (
     <ContextMenu.Root>
       <ContextMenu.Trigger>{header}</ContextMenu.Trigger>
       <ContextMenu.Content>
         <ContextMenu.Item
           onClick={handleSwapDay}
-          disabled={activities.length === 0}
+          disabled={activities.length === 0 || !canSwap}
         >
           Swap activities with another day…
         </ContextMenu.Item>
@@ -820,7 +833,10 @@ const TimetableDayHeader = memo(
       prevProps.gridColumnEnd === nextProps.gridColumnEnd &&
       prevProps.isActive === nextProps.isActive &&
       prevProps.dayIndex === nextProps.dayIndex &&
-      prevProps.userCanModifyTrip === nextProps.userCanModifyTrip
+      prevProps.userCanModifyTrip === nextProps.userCanModifyTrip &&
+      prevProps.trip === nextProps.trip &&
+      prevProps.activities === nextProps.activities &&
+      prevProps.tripDays === nextProps.tripDays
     );
   },
 );

--- a/src/Trip/TripTimetableView/Timetable.tsx
+++ b/src/Trip/TripTimetableView/Timetable.tsx
@@ -5,7 +5,13 @@ import {
   HomeIcon,
   StackIcon,
 } from '@radix-ui/react-icons';
-import { IconButton, Section, Text, Tooltip } from '@radix-ui/themes';
+import {
+  ContextMenu,
+  IconButton,
+  Section,
+  Text,
+  Tooltip,
+} from '@radix-ui/themes';
 import clsx from 'clsx';
 
 import type * as React from 'react';
@@ -54,6 +60,7 @@ import {
   useTripMacroplans,
   useTripTimetableDragging,
 } from '../store/hooks';
+import type { TripSliceTrip } from '../store/types';
 import { TripViewMode } from '../TripViewMode';
 import {
   generateAccommodationGridTemplateColumns,
@@ -63,6 +70,7 @@ import {
   generateMacroplanGridTemplateColumns,
   getMacroplanIndexes,
 } from './macroplan';
+import { SwapDayDialog } from './SwapDay/SwapDayDialog';
 import s from './Timetable.module.scss';
 import { TimetableDialogState } from './TimetableDialogState';
 import { TimetableGrid } from './TimetableGrid';
@@ -549,6 +557,8 @@ export function Timetable() {
               gridColumnStart={`d${String(dayNumber)}`}
               gridColumnEnd={`de${String(dayNumber)}`}
               isActive={isCurrentDay}
+              dayIndex={i}
+              userCanModifyTrip={userCanModifyTrip}
             />
           );
         })}
@@ -712,19 +722,41 @@ function TimetableDayHeaderInner({
   gridColumnStart,
   gridColumnEnd,
   isActive,
+  dayIndex,
+  userCanModifyTrip,
 }: {
   dateString: string;
   gridColumnStart: string;
   gridColumnEnd: string;
   isActive?: boolean;
+  dayIndex: number;
+  userCanModifyTrip: boolean;
 }) {
+  const { trip } = useCurrentTrip();
+  const activities = useTripActivities(trip?.activityIds ?? []);
+  const pushDialog = useBoundStore((state) => state.pushDialog);
+
   const style = useMemo(() => {
     return {
       gridColumnStart: gridColumnStart,
       gridColumnEnd: gridColumnEnd,
     };
   }, [gridColumnStart, gridColumnEnd]);
-  return (
+
+  const handleSwapDay = useCallback(() => {
+    if (!trip) return;
+    const days = dayGroupsFromTrip(trip);
+    const sourceDay = days.find((day) => day.dayIndex === dayIndex);
+    if (!sourceDay) return;
+    pushDialog(SwapDayDialog, {
+      trip,
+      activities,
+      sourceDayIndex: dayIndex,
+      days,
+    });
+  }, [activities, dayIndex, pushDialog, trip]);
+
+  const header = (
     <Text
       as="div"
       size={{ initial: '1', sm: '3' }}
@@ -738,7 +770,47 @@ function TimetableDayHeaderInner({
       {dateString}
     </Text>
   );
+
+  if (!userCanModifyTrip) {
+    return header;
+  }
+
+  return (
+    <ContextMenu.Root>
+      <ContextMenu.Trigger>{header}</ContextMenu.Trigger>
+      <ContextMenu.Content>
+        <ContextMenu.Item
+          onClick={handleSwapDay}
+          disabled={activities.length === 0}
+        >
+          Swap activities with another day…
+        </ContextMenu.Item>
+      </ContextMenu.Content>
+    </ContextMenu.Root>
+  );
 }
+
+function dayGroupsFromTrip(
+  trip: TripSliceTrip,
+): Array<{ dayIndex: number; startMs: number }> {
+  const tripStart = Temporal.Instant.fromEpochMilliseconds(
+    trip.timestampStart,
+  ).toZonedDateTimeISO(trip.timeZone);
+  const tripEnd = Temporal.Instant.fromEpochMilliseconds(
+    trip.timestampEnd,
+  ).toZonedDateTimeISO(trip.timeZone);
+  const days = tripEnd.since(tripStart, { largestUnit: 'days' }).days;
+
+  const result: Array<{ dayIndex: number; startMs: number }> = [];
+  for (let i = 0; i < days; i++) {
+    result.push({
+      dayIndex: i,
+      startMs: tripStart.add({ days: i }).startOfDay().epochMilliseconds,
+    });
+  }
+  return result;
+}
+
 const TimetableDayHeader = memo(
   TimetableDayHeaderInner,
   (prevProps, nextProps) => {
@@ -746,7 +818,9 @@ const TimetableDayHeader = memo(
       prevProps.dateString === nextProps.dateString &&
       prevProps.gridColumnStart === nextProps.gridColumnStart &&
       prevProps.gridColumnEnd === nextProps.gridColumnEnd &&
-      prevProps.isActive === nextProps.isActive
+      prevProps.isActive === nextProps.isActive &&
+      prevProps.dayIndex === nextProps.dayIndex &&
+      prevProps.userCanModifyTrip === nextProps.userCanModifyTrip
     );
   },
 );


### PR DESCRIPTION
Fixes #167: allow swapping the entire day's itinerary to another date.

## What changed
- Right-click a day's date header in the Timetable view and choose **Swap activities with another day…** (only shown to users who can edit the trip).
- A dialog opens to pick the target day, then asks for confirmation.
- All activities with a start date on the source day are moved to the target day, and activities on the target day are moved back to the source day, preserving each activity's wall-clock time and duration (DST-safe via the existing \shiftTimestampToTripDate\).
- After the swap, a toast appears with an **Undo** action to restore the original timestamps.

## Notes
- Scope is activities only (accommodations and macroplans are intentionally untouched).
- 592 insertions (includes unit tests for the swap logic).


<img width="698" height="377" alt="image" src="https://github.com/user-attachments/assets/ff71df3c-3429-49e2-91bb-b862924bfa4c" />


<img width="454" height="129" alt="image" src="https://github.com/user-attachments/assets/138d2e91-8861-4195-b9ed-c2efa12a5793" />
