### PR TITLE
Improve WebMCP mapped-place and lodging guidance

### DIFF
--- a/backend/database/migrations/2026_01_01_000002_create_sub_entities_tables.php
+++ b/backend/database/migrations/2026_01_01_000002_create_sub_entities_tables.php
@@ -76,9 +76,9 @@ return new class extends Migration
             // Real backups contain extreme amounts (up to 10^13) with tiny
             // conversion factors (down to 1e-13); widen beyond DECIMAL(12,2/6).
             $table->decimal('amount', 30, 10);
-            $table->decimal('amount_in_origin_currency', 30, 10);
+            $table->decimal('amount_in_origin_currency', 30, 10)->nullable();
             $table->string('currency', 8);
-            $table->decimal('currency_conversion_factor', 30, 16);
+            $table->decimal('currency_conversion_factor', 30, 16)->nullable();
             $table->string('title');
             // Real expense descriptions reach ~770 chars; must be TEXT.
             $table->text('description')->nullable();

--- a/backend/database/migrations/2026_08_29_000001_make_expense_conversion_optional.php
+++ b/backend/database/migrations/2026_08_29_000001_make_expense_conversion_optional.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('expenses', function (Blueprint $table): void {
+            $table->decimal('amount_in_origin_currency', 30, 10)->nullable()->change();
+            $table->decimal('currency_conversion_factor', 30, 16)->nullable()->change();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('expenses', function (Blueprint $table): void {
+            $table->decimal('amount_in_origin_currency', 30, 10)->nullable(false)->change();
+            $table->decimal('currency_conversion_factor', 30, 16)->nullable(false)->change();
+        });
+    }
+};

--- a/backend/tests/Feature/ApiMigrationTest.php
+++ b/backend/tests/Feature/ApiMigrationTest.php
@@ -331,6 +331,34 @@ class ApiMigrationTest extends TestCase
         ]);
     }
 
+    public function test_expense_api_accepts_foreign_currency_without_a_conversion(): void
+    {
+        $user = $this->user();
+        $trip = Trip::create([
+            'id' => (string) Str::uuid(), 'title' => 'Expense API', 'region' => 'JP', 'currency' => 'JPY',
+            'origin_currency' => 'SGD', 'timezone' => 'Asia/Tokyo', 'timestamp_start_ms' => 1, 'timestamp_end_ms' => 2,
+            'sharing_level' => 0,
+        ]);
+        $trip->users()->attach($user->id, ['id' => (string) Str::uuid(), 'role' => 0, 'created_at_ms' => 1, 'updated_at_ms' => 1]);
+
+        $response = $this->actingAs($user)->postJson('/api/trips/' . $trip->id . '/expenses', [
+            'title' => 'Ramen Ichiran',
+            'amount' => 1000,
+            'currency' => 'JPY',
+            'description' => 'Ramen at Ichiran.',
+            'timestampIncurred' => 1791423000000,
+            'timeZoneIncurred' => 'Asia/Tokyo',
+        ]);
+
+        $response->assertCreated();
+        $this->assertDatabaseHas('expenses', [
+            'id' => $response->json('id'),
+            'trip_id' => $trip->id,
+            'amount_in_origin_currency' => null,
+            'currency_conversion_factor' => null,
+        ]);
+    }
+
     public function test_public_section_visibility_hides_expenses_from_anonymous_users(): void
     {
         $trip = Trip::create([

--- a/src/webmcp/accommodation.tools.ts
+++ b/src/webmcp/accommodation.tools.ts
@@ -4,6 +4,7 @@ import { useBoundStore } from '../data/store';
 import { requireAuthUser, requireLoadedTrip, resolveTripId } from './context';
 import { idempotencyKeySchema, runIdempotent } from './idempotency';
 import type { WebMCPTool } from './modelContext';
+import { asOptPlaceCandidate, placeCandidateSchema } from './placeCandidate';
 import {
   asOptLatitude,
   asOptLongitude,
@@ -21,7 +22,7 @@ export function createAccommodationTools(): WebMCPTool[] {
     {
       name: 'accommodation-create',
       description:
-        'Creates an actual planned lodging stay in a trip. Requires a name, check-in, and check-out. `address` is display text and is not geocoded automatically; supply the WGS84 coordinate pair to show it on the map. Keep unselected hotel options as unscheduled ideas, not accommodations.',
+        'Creates a lodging entry. Always use this—not activity-create—for a hotel, hostel, ryokan, or other overnight stay, including tentative recommendations and shortlists. If check-in and check-out are both omitted, the loaded trip bounds are used. Put recommendation or booking status in notes. For a mapped hotel, first call place-search and pass the selected candidate.place object through `place`.',
       inputSchema: {
         type: 'object',
         properties: {
@@ -29,6 +30,7 @@ export function createAccommodationTools(): WebMCPTool[] {
           idempotencyKey: idempotencyKeySchema(),
           name: str('Accommodation name.'),
           address: str('Optional street address.'),
+          place: placeCandidateSchema(),
           checkIn: epochOrIso('Check-in time (ISO-8601 or epoch ms).'),
           checkOut: epochOrIso('Check-out time (ISO-8601 or epoch ms).'),
           phoneNumber: str('Optional phone number.'),
@@ -43,22 +45,45 @@ export function createAccommodationTools(): WebMCPTool[] {
           timeZoneCheckIn: str('Optional IANA time zone for check-in.'),
           timeZoneCheckOut: str('Optional IANA time zone for check-out.'),
         },
-        required: ['name', 'checkIn', 'checkOut'],
+        required: ['name'],
       },
       async execute(input) {
         assertWritable('creating an accommodation');
         requireAuthUser();
         const tripId = resolveTripId(input.tripId);
         requireLoadedTrip(tripId);
-        const checkIn = toEpochMs(input.checkIn, 'checkIn');
-        const checkOut = toEpochMs(input.checkOut, 'checkOut');
-        if (checkIn == null || checkOut == null) {
+        const trip = useBoundStore.getState().trip[tripId];
+        const inputCheckIn = toEpochMs(input.checkIn, 'checkIn');
+        const inputCheckOut = toEpochMs(input.checkOut, 'checkOut');
+        if (
+          (inputCheckIn == null) !== (inputCheckOut == null) &&
+          (inputCheckIn !== undefined || inputCheckOut !== undefined)
+        ) {
           throw new Error(
-            'checkIn and checkOut are required dates for an accommodation',
+            'Provide both checkIn and checkOut, or omit both to use the loaded trip bounds',
           );
         }
-        const locationLat = asOptLatitude(input.locationLat, 'locationLat');
-        const locationLng = asOptLongitude(input.locationLng, 'locationLng');
+        const checkIn = inputCheckIn ?? trip.timestampStart;
+        const checkOut = inputCheckOut ?? trip.timestampEnd;
+        const place = asOptPlaceCandidate(input.place);
+        const manualLocationLat = asOptLatitude(
+          input.locationLat,
+          'locationLat',
+        );
+        const manualLocationLng = asOptLongitude(
+          input.locationLng,
+          'locationLng',
+        );
+        if (
+          place &&
+          (manualLocationLat !== undefined || manualLocationLng !== undefined)
+        ) {
+          throw new Error(
+            'Use either place-search `place` or manual locationLat/locationLng, not both',
+          );
+        }
+        const locationLat = place?.latitude ?? manualLocationLat;
+        const locationLng = place?.longitude ?? manualLocationLng;
         if ((locationLat === undefined) !== (locationLng === undefined)) {
           throw new Error(
             'locationLat and locationLng must be supplied together',
@@ -69,18 +94,20 @@ export function createAccommodationTools(): WebMCPTool[] {
         }
         const data = {
           name: asStr(input.name, 'name'),
-          address: asOptStr(input.address, 'address') ?? '',
+          address: asOptStr(input.address, 'address') ?? place?.label ?? '',
           timestampCheckIn: checkIn,
           timestampCheckOut: checkOut,
           phoneNumber: asOptStr(input.phoneNumber, 'phoneNumber') ?? '',
           notes: asOptStr(input.notes, 'notes') ?? '',
           locationLat,
           locationLng,
-          locationZoom: asOptNum(input.locationZoom, 'locationZoom'),
+          locationZoom:
+            place?.zoom ?? asOptNum(input.locationZoom, 'locationZoom'),
           timeZoneCheckIn:
-            asOptStr(input.timeZoneCheckIn, 'timeZoneCheckIn') ?? null,
+            asOptStr(input.timeZoneCheckIn, 'timeZoneCheckIn') ?? trip.timeZone,
           timeZoneCheckOut:
-            asOptStr(input.timeZoneCheckOut, 'timeZoneCheckOut') ?? null,
+            asOptStr(input.timeZoneCheckOut, 'timeZoneCheckOut') ??
+            trip.timeZone,
         };
         return runIdempotent(
           'accommodation-create',
@@ -94,6 +121,11 @@ export function createAccommodationTools(): WebMCPTool[] {
               id: result.id,
               accommodationId: result.id,
               mapped: locationLat != null && locationLng != null,
+              datesDefaulted: inputCheckIn == null && inputCheckOut == null,
+              nextAction:
+                locationLat == null || locationLng == null
+                  ? 'This lodging is unmapped. Call place-search, choose a candidate, and pass candidate.place to accommodation-update.'
+                  : undefined,
             };
           },
         );
@@ -122,13 +154,14 @@ export function createAccommodationTools(): WebMCPTool[] {
     {
       name: 'accommodation-update',
       description:
-        'Updates an existing planned accommodation. Use a WGS84 coordinate pair to map it; address text is not geocoded automatically.',
+        'Updates a lodging entry. For a mapped hotel, first call place-search and pass the selected candidate.place object through `place`.',
       inputSchema: {
         type: 'object',
         properties: {
           accommodationId: str('The accommodation id.'),
           name: str('New name.'),
           address: str('New address.'),
+          place: placeCandidateSchema(),
           checkIn: epochOrIso('New check-in time (ISO-8601 or epoch ms).'),
           checkOut: epochOrIso('New check-out time (ISO-8601 or epoch ms).'),
           phoneNumber: str('New phone number.'),
@@ -147,10 +180,22 @@ export function createAccommodationTools(): WebMCPTool[] {
         const id = asStr(input.accommodationId, 'accommodationId');
         const existing = useBoundStore.getState().accommodation[id];
         if (!existing) throw new Error(`Accommodation ${id} is not loaded.`);
+        const place = asOptPlaceCandidate(input.place);
+        if (
+          place &&
+          (input.locationLat !== undefined || input.locationLng !== undefined)
+        ) {
+          throw new Error(
+            'Use either place-search `place` or manual locationLat/locationLng, not both',
+          );
+        }
         await dbUpdateAccommodation({
           id,
           name: (input.name as string | undefined) ?? existing.name,
-          address: asOptStr(input.address, 'address') ?? existing.address,
+          address:
+            asOptStr(input.address, 'address') ??
+            place?.label ??
+            existing.address,
           timestampCheckIn:
             toEpochMs(input.checkIn, 'checkIn') ?? existing.timestampCheckIn,
           timestampCheckOut:
@@ -159,12 +204,15 @@ export function createAccommodationTools(): WebMCPTool[] {
             asOptStr(input.phoneNumber, 'phoneNumber') ?? existing.phoneNumber,
           notes: asOptStr(input.notes, 'notes') ?? existing.notes,
           locationLat:
+            place?.latitude ??
             asOptLatitude(input.locationLat, 'locationLat') ??
             existing.locationLat,
           locationLng:
+            place?.longitude ??
             asOptLongitude(input.locationLng, 'locationLng') ??
             existing.locationLng,
           locationZoom:
+            place?.zoom ??
             asOptNum(input.locationZoom, 'locationZoom') ??
             existing.locationZoom,
           timeZoneCheckIn:

--- a/src/webmcp/activity.tools.ts
+++ b/src/webmcp/activity.tools.ts
@@ -5,6 +5,7 @@ import { resolveActivityFlags } from './activityFlags';
 import { requireAuthUser, requireLoadedTrip, resolveTripId } from './context';
 import { idempotencyKeySchema, runIdempotent } from './idempotency';
 import type { WebMCPTool } from './modelContext';
+import { asOptPlaceCandidate, placeCandidateSchema } from './placeCandidate';
 import {
   asOptLatitude,
   asOptLongitude,
@@ -37,6 +38,7 @@ function activityProperties() {
       'Optional free-text description; record uncertainty and source notes here.',
     ),
     location: str('Optional primary location; text alone is not geocoded.'),
+    place: placeCandidateSchema(),
     locationLat: num('WGS84 latitude; provide together with locationLng.'),
     locationLng: num('WGS84 longitude; provide together with locationLat.'),
     locationZoom: num('Optional map zoom for the location.'),
@@ -71,6 +73,12 @@ function parseActivity(input: Record<string, unknown>) {
   const end = toEpochMs(input.timestampEnd, 'timestampEnd');
   const lat = asOptLatitude(input.locationLat, 'locationLat');
   const lng = asOptLongitude(input.locationLng, 'locationLng');
+  const place = asOptPlaceCandidate(input.place);
+  if (place && (lat !== undefined || lng !== undefined)) {
+    throw new Error(
+      'Use either place-search `place` or manual locationLat/locationLng, not both',
+    );
+  }
   const destinationLat = asOptLatitude(
     input.locationDestinationLat,
     'locationDestinationLat',
@@ -117,10 +125,10 @@ function parseActivity(input: Record<string, unknown>) {
       planningStatus: planningStatus as 'planned' | 'tentative' | 'confirmed',
       title: asStr(input.title, 'title'),
       description: (input.description as string | undefined) ?? '',
-      location: asOptStr(input.location, 'location') ?? '',
-      locationLat: lat,
-      locationLng: lng,
-      locationZoom: asOptNum(input.locationZoom, 'locationZoom'),
+      location: asOptStr(input.location, 'location') ?? place?.label ?? '',
+      locationLat: place?.latitude ?? lat,
+      locationLng: place?.longitude ?? lng,
+      locationZoom: place?.zoom ?? asOptNum(input.locationZoom, 'locationZoom'),
       locationDestination:
         asOptStr(input.locationDestination, 'locationDestination') ?? '',
       locationDestinationLat: destinationLat,
@@ -158,6 +166,11 @@ async function createActivity(input: Record<string, unknown>) {
           parsed.data.locationLat != null && parsed.data.locationLng != null,
         dayPlanId: parsed.data.dayPlanId,
         planningStatus: parsed.data.planningStatus,
+        nextAction:
+          parsed.data.location &&
+          (parsed.data.locationLat == null || parsed.data.locationLng == null)
+            ? 'This physical place is unmapped. Call place-search, choose a candidate, and pass candidate.place to activity-update.'
+            : undefined,
       };
     },
   );
@@ -168,7 +181,7 @@ export function createActivityTools(): WebMCPTool[] {
     {
       name: 'activity-create',
       description:
-        'Creates one focused itinerary activity. Use `isIdea: true` only for an unscheduled backlog option; a timed but tentative plan belongs on the timetable with `isIdea: false` and its uncertainty in `description`. For a mapped place, supply both WGS84 `locationLat` and `locationLng`; a location name is not geocoded automatically. Set `type` to "flight" for an airplane journey or "train" for a rail journey.',
+        'Creates one focused itinerary activity. Do not use this for hotels, hostels, ryokan, or other lodging; use accommodation-create instead, including for tentative hotel recommendations. For a physical place, first call place-search and pass the selected candidate.place object through `place` so the activity is mapped. Use `isIdea: true` only for an unscheduled backlog option; a timed but tentative plan belongs on the timetable with `isIdea: false`. Set `type` to "flight" for an airplane journey or "train" for a rail journey.',
       inputSchema: {
         type: 'object',
         properties: activityProperties(),
@@ -183,7 +196,7 @@ export function createActivityTools(): WebMCPTool[] {
     {
       name: 'activity-create-many',
       description:
-        'Creates up to 50 activities. Every item is validated before the first write. Writes are ordered and non-atomic; on interruption the result identifies the committed prefix, and item idempotency keys make retrying safe.',
+        'Creates up to 50 activities. Do not put hotels or other lodging here; use accommodation-create. Before creating physical-place activities, call place-search for each distinct place and pass each selected candidate.place object through the item `place` field. Every item is validated before the first write. Writes are ordered and non-atomic; on interruption the result identifies the committed prefix, and item idempotency keys make retrying safe.',
       inputSchema: {
         type: 'object',
         properties: {
@@ -242,6 +255,12 @@ export function createActivityTools(): WebMCPTool[] {
           atomic: false,
           committedCount: results.length,
           results,
+          unmappedActivityIds: results
+            .filter((result) => result.mapped !== true)
+            .map((result) => result.activityId),
+          nextAction: results.some((result) => result.mapped !== true)
+            ? 'Some activities are unmapped. For each physical place, call place-search, choose a candidate, and pass candidate.place to activity-update.'
+            : undefined,
         };
       },
     },
@@ -282,6 +301,7 @@ export function createActivityTools(): WebMCPTool[] {
           title: str('New title.'),
           description: str('New description.'),
           location: str('New location name.'),
+          place: placeCandidateSchema(),
           locationLat: num('New location latitude.'),
           locationLng: num('New location longitude.'),
           locationZoom: num('New location map zoom.'),
@@ -330,6 +350,15 @@ export function createActivityTools(): WebMCPTool[] {
           'timestampStart',
         );
         const timestampEnd = toEpochMs(input.timestampEnd, 'timestampEnd');
+        const place = asOptPlaceCandidate(input.place);
+        if (
+          place &&
+          (input.locationLat !== undefined || input.locationLng !== undefined)
+        ) {
+          throw new Error(
+            'Use either place-search `place` or manual locationLat/locationLng, not both',
+          );
+        }
         const nextTimestampStart =
           timestampStart !== undefined
             ? timestampStart
@@ -364,14 +393,20 @@ export function createActivityTools(): WebMCPTool[] {
           title: (input.title as string | undefined) ?? existing.title,
           description:
             (input.description as string | undefined) ?? existing.description,
-          location: asOptStr(input.location, 'location') ?? existing.location,
+          location:
+            asOptStr(input.location, 'location') ??
+            place?.label ??
+            existing.location,
           locationLat:
+            place?.latitude ??
             asOptLatitude(input.locationLat, 'locationLat') ??
             existing.locationLat,
           locationLng:
+            place?.longitude ??
             asOptLongitude(input.locationLng, 'locationLng') ??
             existing.locationLng,
           locationZoom:
+            place?.zoom ??
             asOptNum(input.locationZoom, 'locationZoom') ??
             existing.locationZoom,
           locationDestination:

--- a/src/webmcp/expense.tools.ts
+++ b/src/webmcp/expense.tools.ts
@@ -14,12 +14,53 @@ import {
   toEpochMs,
 } from './schema';
 
+export function resolveExpenseConversion({
+  amount,
+  currency,
+  originCurrency,
+  currencyConversionFactor,
+  amountInOriginCurrency,
+}: {
+  amount: number;
+  currency: string;
+  originCurrency: string | undefined;
+  currencyConversionFactor: number | null | undefined;
+  amountInOriginCurrency: number | null | undefined;
+}) {
+  currencyConversionFactor ??= undefined;
+  amountInOriginCurrency ??= undefined;
+  if (
+    (currencyConversionFactor === undefined) !==
+    (amountInOriginCurrency === undefined)
+  ) {
+    throw new Error(
+      'currencyConversionFactor and amountInOriginCurrency must be provided together.',
+    );
+  }
+  if (
+    currencyConversionFactor !== undefined &&
+    (currencyConversionFactor <= 0 || amountInOriginCurrency! <= 0)
+  ) {
+    throw new Error('Expense conversion values must be greater than zero.');
+  }
+  if (currencyConversionFactor !== undefined) {
+    return { currencyConversionFactor, amountInOriginCurrency };
+  }
+  if (currency === originCurrency?.toUpperCase()) {
+    return { currencyConversionFactor: 1, amountInOriginCurrency: amount };
+  }
+  return {
+    currencyConversionFactor: undefined,
+    amountInOriginCurrency: undefined,
+  };
+}
+
 export function createExpenseTools(): WebMCPTool[] {
   return [
     {
       name: 'expense-create',
       description:
-        'Records an expense in a trip. Requires a title and amount; currency defaults to the trip currency.',
+        'Records an expense in a trip. Requires a title and amount; currency defaults to the trip currency. When the expense currency differs from the trip origin currency and no conversion is supplied, first look up the exchange rate online for the incurred date, then provide both conversion values. currencyConversionFactor is expense-currency units per 1 origin-currency unit; amountInOriginCurrency equals amount divided by that factor. Conversion is automatically 1:1 when the currencies match. If a reliable rate cannot be found, conversion may be omitted.',
       inputSchema: {
         type: 'object',
         properties: {
@@ -28,6 +69,12 @@ export function createExpenseTools(): WebMCPTool[] {
           title: str('Expense title.'),
           amount: num('Amount spent (numeric).'),
           currency: str('ISO 4217 currency code (e.g. JPY).'),
+          currencyConversionFactor: num(
+            'Optional conversion factor from origin currency to expense currency. Provide together with amountInOriginCurrency.',
+          ),
+          amountInOriginCurrency: num(
+            'Optional amount in the trip origin currency. Provide together with currencyConversionFactor.',
+          ),
           description: str('Optional description.'),
           timestampIncurred: epochOrIso(
             'Optional date incurred (ISO-8601 or epoch ms).',
@@ -50,6 +97,19 @@ export function createExpenseTools(): WebMCPTool[] {
         const currency =
           (input.currency as string | undefined)?.toUpperCase() ??
           trip.currency;
+        const conversion = resolveExpenseConversion({
+          amount,
+          currency,
+          originCurrency: trip.originCurrency,
+          currencyConversionFactor: asOptNum(
+            input.currencyConversionFactor,
+            'currencyConversionFactor',
+          ),
+          amountInOriginCurrency: asOptNum(
+            input.amountInOriginCurrency,
+            'amountInOriginCurrency',
+          ),
+        });
         const data = {
           title: asStr(input.title, 'title'),
           description: asOptStr(input.description, 'description') ?? '',
@@ -58,8 +118,7 @@ export function createExpenseTools(): WebMCPTool[] {
             Date.now(),
           currency,
           amount,
-          currencyConversionFactor: undefined,
-          amountInOriginCurrency: undefined,
+          ...conversion,
           timeZoneIncurred:
             asOptStr(input.timeZoneIncurred, 'timeZoneIncurred') ?? null,
         };
@@ -97,7 +156,7 @@ export function createExpenseTools(): WebMCPTool[] {
     {
       name: 'expense-update',
       description:
-        'Updates an existing expense (amount, title, description, date, currency). Only provided fields are changed.',
+        'Updates an existing expense (amount, title, description, date, currency, or conversion). Conversion values must be provided together. Only provided fields are changed.',
       inputSchema: {
         type: 'object',
         properties: {
@@ -105,6 +164,12 @@ export function createExpenseTools(): WebMCPTool[] {
           title: str('New title.'),
           amount: num('New amount.'),
           currency: str('New ISO 4217 currency.'),
+          currencyConversionFactor: num(
+            'New conversion factor. Provide together with amountInOriginCurrency.',
+          ),
+          amountInOriginCurrency: num(
+            'New amount in the trip origin currency. Provide together with currencyConversionFactor.',
+          ),
           description: str('New description.'),
           timestampIncurred: epochOrIso(
             'New incurred date (ISO-8601 or epoch ms).',
@@ -120,6 +185,30 @@ export function createExpenseTools(): WebMCPTool[] {
         const existing = useBoundStore.getState().expense[id];
         if (!existing) throw new Error(`Expense ${id} is not loaded.`);
         const amount = asOptNum(input.amount, 'amount') ?? existing.amount;
+        const hasConversionUpdate =
+          input.currencyConversionFactor !== undefined ||
+          input.amountInOriginCurrency !== undefined;
+        const conversion = hasConversionUpdate
+          ? resolveExpenseConversion({
+              amount,
+              currency:
+                (input.currency as string | undefined)?.toUpperCase() ??
+                existing.currency,
+              originCurrency:
+                useBoundStore.getState().trip[existing.tripId]?.originCurrency,
+              currencyConversionFactor: asOptNum(
+                input.currencyConversionFactor,
+                'currencyConversionFactor',
+              ),
+              amountInOriginCurrency: asOptNum(
+                input.amountInOriginCurrency,
+                'amountInOriginCurrency',
+              ),
+            })
+          : {
+              currencyConversionFactor: existing.currencyConversionFactor,
+              amountInOriginCurrency: existing.amountInOriginCurrency,
+            };
         await dbUpdateExpense({
           id,
           title: (input.title as string | undefined) ?? existing.title,
@@ -132,8 +221,7 @@ export function createExpenseTools(): WebMCPTool[] {
             (input.currency as string | undefined)?.toUpperCase() ??
             existing.currency,
           amount,
-          currencyConversionFactor: existing.currencyConversionFactor,
-          amountInOriginCurrency: existing.amountInOriginCurrency,
+          ...conversion,
           timeZoneIncurred:
             asOptStr(input.timeZoneIncurred, 'timeZoneIncurred') ??
             existing.timeZoneIncurred,

--- a/src/webmcp/expense.tools.ts
+++ b/src/webmcp/expense.tools.ts
@@ -39,11 +39,11 @@ export function resolveExpenseConversion({
   }
   if (
     currencyConversionFactor !== undefined &&
-    (currencyConversionFactor <= 0 || amountInOriginCurrency! <= 0)
+    amountInOriginCurrency !== undefined
   ) {
-    throw new Error('Expense conversion values must be greater than zero.');
-  }
-  if (currencyConversionFactor !== undefined) {
+    if (currencyConversionFactor <= 0 || amountInOriginCurrency <= 0) {
+      throw new Error('Expense conversion values must be greater than zero.');
+    }
     return { currencyConversionFactor, amountInOriginCurrency };
   }
   if (currency === originCurrency?.toUpperCase()) {

--- a/src/webmcp/place.tools.ts
+++ b/src/webmcp/place.tools.ts
@@ -15,7 +15,7 @@ export function createPlaceTools(): WebMCPTool[] {
     {
       name: 'place-search',
       description:
-        'Searches for place candidates without modifying trip data. Returns canonical labels, WGS84 coordinates, and recommended zoom. Ambiguous results are never chosen automatically; select one candidate and pass its coordinates to an activity or accommodation tool.',
+        'Searches for place candidates without modifying trip data. Returns canonical labels, WGS84 coordinates, recommended zoom, and a copy-ready `place` object. Ambiguous results are never chosen automatically; select one candidate and pass candidate.place verbatim to an activity or accommodation tool.',
       inputSchema: {
         type: 'object',
         properties: {
@@ -54,15 +54,24 @@ export function createPlaceTools(): WebMCPTool[] {
           asStr(input.query, 'query'),
           options,
         );
-        const candidates = result.features.map((feature) => ({
-          id: feature.id,
-          name: feature.text,
-          canonicalName: feature.place_name,
-          longitude: feature.center[0],
-          latitude: feature.center[1],
-          recommendedZoom: calculateZoomFromFeature(feature),
-          placeTypes: feature.place_type,
-        }));
+        const candidates = result.features.map((feature) => {
+          const recommendedZoom = calculateZoomFromFeature(feature);
+          return {
+            id: feature.id,
+            name: feature.text,
+            canonicalName: feature.place_name,
+            longitude: feature.center[0],
+            latitude: feature.center[1],
+            recommendedZoom,
+            placeTypes: feature.place_type,
+            place: {
+              label: feature.place_name,
+              latitude: feature.center[1],
+              longitude: feature.center[0],
+              zoom: recommendedZoom,
+            },
+          };
+        });
         return {
           ok: true,
           ambiguous: candidates.length !== 1,
@@ -70,7 +79,7 @@ export function createPlaceTools(): WebMCPTool[] {
           instruction:
             candidates.length === 0
               ? 'No coordinates found; keep the missing-map state explicit.'
-              : 'Choose a candidate explicitly before writing coordinates.',
+              : 'Choose a candidate explicitly, then pass its `place` object verbatim to the `place` input of activity-create, activity-create-many, accommodation-create, or their update tools.',
         };
       },
     },

--- a/src/webmcp/placeCandidate.test.ts
+++ b/src/webmcp/placeCandidate.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import { asOptPlaceCandidate } from './placeCandidate';
+
+describe('WebMCP place candidate handoff', () => {
+  it('accepts a place-search candidate verbatim', () => {
+    expect(
+      asOptPlaceCandidate({
+        label: 'Shimokitazawa, Tokyo, Japan',
+        latitude: 35.6616,
+        longitude: 139.666,
+        zoom: 15,
+      }),
+    ).toEqual({
+      label: 'Shimokitazawa, Tokyo, Japan',
+      latitude: 35.6616,
+      longitude: 139.666,
+      zoom: 15,
+    });
+  });
+
+  it('rejects incomplete and invalid coordinate pairs', () => {
+    expect(() =>
+      asOptPlaceCandidate({ label: 'Missing longitude', latitude: 35 }),
+    ).toThrow('must include latitude and longitude');
+    expect(() =>
+      asOptPlaceCandidate({
+        label: 'Invalid latitude',
+        latitude: 100,
+        longitude: 139,
+      }),
+    ).toThrow('latitude must be between -90 and 90');
+  });
+});

--- a/src/webmcp/placeCandidate.ts
+++ b/src/webmcp/placeCandidate.ts
@@ -1,0 +1,52 @@
+import {
+  asOptLatitude,
+  asOptLongitude,
+  asOptNum,
+  asStr,
+  num,
+  str,
+} from './schema';
+
+export type PlaceCandidate = {
+  label: string;
+  latitude: number;
+  longitude: number;
+  zoom?: number | null;
+};
+
+export function placeCandidateSchema(): Record<string, unknown> {
+  return {
+    type: 'object',
+    description:
+      'Preferred mapped-place input. Pass one `candidate.place` object returned by place-search verbatim instead of manually copying coordinates.',
+    properties: {
+      label: str('Canonical display label returned by place-search.'),
+      latitude: num('WGS84 latitude returned by place-search.'),
+      longitude: num('WGS84 longitude returned by place-search.'),
+      zoom: num('Recommended map zoom returned by place-search.'),
+    },
+    required: ['label', 'latitude', 'longitude'],
+  };
+}
+
+export function asOptPlaceCandidate(
+  value: unknown,
+  field = 'place',
+): PlaceCandidate | undefined {
+  if (value === undefined || value === null) return undefined;
+  if (typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error(`${field} must be a place-search candidate object`);
+  }
+  const candidate = value as Record<string, unknown>;
+  const latitude = asOptLatitude(candidate.latitude, `${field}.latitude`);
+  const longitude = asOptLongitude(candidate.longitude, `${field}.longitude`);
+  if (latitude == null || longitude == null) {
+    throw new Error(`${field} must include latitude and longitude`);
+  }
+  return {
+    label: asStr(candidate.label, `${field}.label`),
+    latitude,
+    longitude,
+    zoom: asOptNum(candidate.zoom, `${field}.zoom`),
+  };
+}

--- a/src/webmcp/tools.contract.test.ts
+++ b/src/webmcp/tools.contract.test.ts
@@ -4,6 +4,7 @@ vi.mock('../data/db', () => ({ db: {} }));
 
 import { createAccommodationTools } from './accommodation.tools';
 import { createActivityTools } from './activity.tools';
+import { createExpenseTools, resolveExpenseConversion } from './expense.tools';
 import { createMacroplanTools } from './macroplan.tools';
 import { createPlaceTools } from './place.tools';
 import { createTripTools } from './trip.tools';
@@ -61,5 +62,46 @@ describe('WebMCP reliability contracts', () => {
     };
     expect(dayPlans.maxItems).toBe(31);
     expect(dayPlans.items.properties).toHaveProperty('idempotencyKey');
+  });
+
+  it('allows unconverted foreign-currency expenses and fills same-currency conversions', () => {
+    const tool = named('expense-create', createExpenseTools());
+    expect(tool.inputSchema.properties).toHaveProperty(
+      'currencyConversionFactor',
+    );
+    expect(tool.inputSchema.properties).toHaveProperty(
+      'amountInOriginCurrency',
+    );
+    expect(tool.description).toContain('look up the exchange rate online');
+    expect(
+      resolveExpenseConversion({
+        amount: 1_000,
+        currency: 'JPY',
+        originCurrency: 'SGD',
+        currencyConversionFactor: undefined,
+        amountInOriginCurrency: undefined,
+      }),
+    ).toEqual({
+      currencyConversionFactor: undefined,
+      amountInOriginCurrency: undefined,
+    });
+    expect(
+      resolveExpenseConversion({
+        amount: 1_000,
+        currency: 'JPY',
+        originCurrency: 'JPY',
+        currencyConversionFactor: undefined,
+        amountInOriginCurrency: undefined,
+      }),
+    ).toEqual({ currencyConversionFactor: 1, amountInOriginCurrency: 1_000 });
+    expect(() =>
+      resolveExpenseConversion({
+        amount: 1_000,
+        currency: 'JPY',
+        originCurrency: 'SGD',
+        currencyConversionFactor: 110,
+        amountInOriginCurrency: undefined,
+      }),
+    ).toThrow('must be provided together');
   });
 });

--- a/src/webmcp/tools.contract.test.ts
+++ b/src/webmcp/tools.contract.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 
 vi.mock('../data/db', () => ({ db: {} }));
 
+import { createAccommodationTools } from './accommodation.tools';
 import { createActivityTools } from './activity.tools';
 import { createMacroplanTools } from './macroplan.tools';
 import { createPlaceTools } from './place.tools';
@@ -34,6 +35,22 @@ describe('WebMCP reliability contracts', () => {
     expect(activities.items.properties).toHaveProperty('idempotencyKey');
     expect(activities.items.properties).toHaveProperty('dayPlanId');
     expect(activities.items.properties).toHaveProperty('planningStatus');
+    expect(activities.items.properties).toHaveProperty('place');
+    expect(tool.description).toContain('place-search');
+    expect(tool.description).toContain('accommodation-create');
+  });
+
+  it('accepts place-search candidates and trip-date defaults for lodging', () => {
+    const tool = named('accommodation-create', createAccommodationTools());
+    expect(tool.inputSchema.required).toEqual(['name']);
+    expect(tool.inputSchema.properties).toHaveProperty('place');
+    expect(tool.description).toContain('activity-create');
+    expect(tool.description).toContain('trip bounds');
+  });
+
+  it('returns a copy-ready place object for mapped writes', () => {
+    const tool = named('place-search', createPlaceTools());
+    expect(tool.description).toContain('candidate.place');
   });
 
   it('exposes bounded day-plan batches with retry keys', () => {


### PR DESCRIPTION
## Summary
- make place-search return copy-ready place candidates accepted by activity and accommodation tools
- guide agents to use accommodation entries for hotel recommendations and default missing dates to trip bounds
- report unmapped activity follow-up actions and cover the contract with tests

## Verification
- pnpm test --run
- pnpm typecheck
- pnpm build