### PR TITLE
feat(webmcp): add batch creation tools

### DIFF
--- a/src/webmcp/accommodation.tools.ts
+++ b/src/webmcp/accommodation.tools.ts
@@ -1,7 +1,15 @@
-import { dbAddAccommodation, dbUpdateAccommodation } from '../Accommodation/db';
+import {
+  dbAddAccommodation,
+  dbDeleteAccommodation,
+  dbUpdateAccommodation,
+} from '../Accommodation/db';
 import { assertWritable } from '../data/backendConfig';
 import { useBoundStore } from '../data/store';
 import { requireAuthUser, requireLoadedTrip, resolveTripId } from './context';
+import {
+  deletionConfirmationSchema,
+  requireDeletionConfirmation,
+} from './destructive';
 import { idempotencyKeySchema, runIdempotent } from './idempotency';
 import type { WebMCPTool } from './modelContext';
 import { asOptPlaceCandidate, placeCandidateSchema } from './placeCandidate';
@@ -210,6 +218,29 @@ export function createAccommodationTools(): WebMCPTool[] {
           committedCount: results.length,
           results,
         };
+      },
+    },
+    {
+      name: 'accommodation-delete',
+      description:
+        'Destructive: permanently deletes one accommodation stay from the trip. Call only after the user explicitly confirms the exact lodging deletion.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          accommodationId: str('The accommodation id to permanently delete.'),
+          confirmDelete: deletionConfirmationSchema(),
+        },
+        required: ['accommodationId', 'confirmDelete'],
+      },
+      async execute(input) {
+        assertWritable('deleting an accommodation');
+        requireAuthUser();
+        const accommodationId = asStr(input.accommodationId, 'accommodationId');
+        if (!useBoundStore.getState().accommodation[accommodationId])
+          throw new Error(`Accommodation ${accommodationId} is not loaded.`);
+        requireDeletionConfirmation(input.confirmDelete);
+        await dbDeleteAccommodation(accommodationId);
+        return { ok: true, deletedAccommodationId: accommodationId };
       },
     },
     {

--- a/src/webmcp/accommodation.tools.ts
+++ b/src/webmcp/accommodation.tools.ts
@@ -132,6 +132,87 @@ export function createAccommodationTools(): WebMCPTool[] {
       },
     },
     {
+      name: 'accommodation-create-many',
+      description:
+        'Creates up to 50 lodging entries for confirmed or planned stays. Each item is processed in order and may use place-search `place` coordinates. Writes are non-atomic; per-item idempotency keys make retrying safe.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          tripId: str('Trip id applied to lodgings that omit tripId.'),
+          accommodations: {
+            type: 'array',
+            minItems: 1,
+            maxItems: 50,
+            description: 'Ordered lodging entries to create.',
+            items: {
+              type: 'object',
+              properties: {
+                idempotencyKey: idempotencyKeySchema(),
+                name: str('Accommodation name.'),
+                address: str('Optional street address.'),
+                place: placeCandidateSchema(),
+                checkIn: epochOrIso('Check-in time (ISO-8601 or epoch ms).'),
+                checkOut: epochOrIso('Check-out time (ISO-8601 or epoch ms).'),
+                phoneNumber: str('Optional phone number.'),
+                notes: str('Optional notes.'),
+                locationLat: num('WGS84 latitude (-90 to 90).'),
+                locationLng: num('WGS84 longitude (-180 to 180).'),
+                locationZoom: num('Optional map zoom.'),
+                timeZoneCheckIn: str('Optional IANA time zone for check-in.'),
+                timeZoneCheckOut: str('Optional IANA time zone for check-out.'),
+              },
+              required: ['name'],
+            },
+          },
+        },
+        required: ['accommodations'],
+      },
+      async execute(input) {
+        assertWritable('creating accommodations');
+        requireAuthUser();
+        if (
+          !Array.isArray(input.accommodations) ||
+          input.accommodations.length < 1 ||
+          input.accommodations.length > 50
+        ) {
+          throw new Error('accommodations must contain between 1 and 50 items');
+        }
+        const createOne = createAccommodationTools().find(
+          (tool) => tool.name === 'accommodation-create',
+        );
+        if (!createOne) throw new Error('accommodation-create is unavailable');
+        const results: Array<Record<string, unknown>> = [];
+        for (let index = 0; index < input.accommodations.length; index++) {
+          const item = input.accommodations[index];
+          if (!item || typeof item !== 'object')
+            throw new Error(`accommodations[${index}] must be an object`);
+          try {
+            results.push(
+              (await createOne.execute({
+                tripId: input.tripId,
+                ...(item as Record<string, unknown>),
+              })) as Record<string, unknown>,
+            );
+          } catch (error) {
+            return {
+              ok: false,
+              atomic: false,
+              committedCount: results.length,
+              failedIndex: index,
+              results,
+              error: error instanceof Error ? error.message : String(error),
+            };
+          }
+        }
+        return {
+          ok: true,
+          atomic: false,
+          committedCount: results.length,
+          results,
+        };
+      },
+    },
+    {
       name: 'accommodation-get',
       description:
         'Returns an accommodation from the locally loaded state by id.',

--- a/src/webmcp/activity.tools.ts
+++ b/src/webmcp/activity.tools.ts
@@ -1,8 +1,16 @@
-import { dbAddActivity, dbUpdateActivity } from '../Activity/db';
+import {
+  dbAddActivity,
+  dbDeleteActivity,
+  dbUpdateActivity,
+} from '../Activity/db';
 import { assertWritable } from '../data/backendConfig';
 import { useBoundStore } from '../data/store';
 import { resolveActivityFlags } from './activityFlags';
 import { requireAuthUser, requireLoadedTrip, resolveTripId } from './context';
+import {
+  deletionConfirmationSchema,
+  requireDeletionConfirmation,
+} from './destructive';
 import { idempotencyKeySchema, runIdempotent } from './idempotency';
 import type { WebMCPTool } from './modelContext';
 import { asOptPlaceCandidate, placeCandidateSchema } from './placeCandidate';
@@ -262,6 +270,29 @@ export function createActivityTools(): WebMCPTool[] {
             ? 'Some activities are unmapped. For each physical place, call place-search, choose a candidate, and pass candidate.place to activity-update.'
             : undefined,
         };
+      },
+    },
+    {
+      name: 'activity-delete',
+      description:
+        'Destructive: permanently deletes one activity from the trip. Call only after the user explicitly confirms the exact activity deletion.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          activityId: str('The activity id to permanently delete.'),
+          confirmDelete: deletionConfirmationSchema(),
+        },
+        required: ['activityId', 'confirmDelete'],
+      },
+      async execute(input) {
+        assertWritable('deleting an activity');
+        requireAuthUser();
+        const activityId = asStr(input.activityId, 'activityId');
+        if (!useBoundStore.getState().activity[activityId])
+          throw new Error(`Activity ${activityId} is not loaded.`);
+        requireDeletionConfirmation(input.confirmDelete);
+        await dbDeleteActivity(activityId);
+        return { ok: true, deletedActivityId: activityId };
       },
     },
     {

--- a/src/webmcp/comment.tools.ts
+++ b/src/webmcp/comment.tools.ts
@@ -118,6 +118,79 @@ export function createCommentTools(): WebMCPTool[] {
       },
     },
     {
+      name: 'comment-add-many',
+      description:
+        'Adds up to 50 comments within one trip, useful for importing notes. Each item identifies its target object. Writes are ordered and non-atomic; per-item idempotency keys make retrying safe.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          tripId: str('Trip id applied to comments that omit tripId.'),
+          comments: {
+            type: 'array',
+            minItems: 1,
+            maxItems: 50,
+            description: 'Ordered comments to add.',
+            items: {
+              type: 'object',
+              properties: {
+                idempotencyKey: idempotencyKeySchema(),
+                content: str('Comment text.'),
+                objectType: strEnum('The target object type.', OBJECT_TYPES),
+                objectId: str('The target object id.'),
+                groupId: str('Optional existing comment-group id.'),
+              },
+              required: ['content', 'objectType', 'objectId'],
+            },
+          },
+        },
+        required: ['comments'],
+      },
+      async execute(input) {
+        assertWritable('adding comments');
+        requireAuthUser();
+        if (
+          !Array.isArray(input.comments) ||
+          input.comments.length < 1 ||
+          input.comments.length > 50
+        ) {
+          throw new Error('comments must contain between 1 and 50 items');
+        }
+        const createOne = createCommentTools().find(
+          (tool) => tool.name === 'comment-add',
+        );
+        if (!createOne) throw new Error('comment-add is unavailable');
+        const results: Array<Record<string, unknown>> = [];
+        for (let index = 0; index < input.comments.length; index++) {
+          const item = input.comments[index];
+          if (!item || typeof item !== 'object')
+            throw new Error(`comments[${index}] must be an object`);
+          try {
+            results.push(
+              (await createOne.execute({
+                tripId: input.tripId,
+                ...(item as Record<string, unknown>),
+              })) as Record<string, unknown>,
+            );
+          } catch (error) {
+            return {
+              ok: false,
+              atomic: false,
+              committedCount: results.length,
+              failedIndex: index,
+              results,
+              error: error instanceof Error ? error.message : String(error),
+            };
+          }
+        }
+        return {
+          ok: true,
+          atomic: false,
+          committedCount: results.length,
+          results,
+        };
+      },
+    },
+    {
       name: 'comment-update',
       description: 'Edits the text of an existing comment.',
       inputSchema: {

--- a/src/webmcp/comment.tools.ts
+++ b/src/webmcp/comment.tools.ts
@@ -2,12 +2,17 @@ import {
   COMMENT_GROUP_OBJECT_TYPE,
   type DbCommentGroupObjectType,
   dbAddComment,
+  dbDeleteComment,
   dbUpdateComment,
   dbUpdateCommentGroupStatus,
 } from '../Comment/db';
 import { assertWritable } from '../data/backendConfig';
 import { useBoundStore } from '../data/store';
 import { requireAuthUser, requireLoadedTrip, resolveTripId } from './context';
+import {
+  deletionConfirmationSchema,
+  requireDeletionConfirmation,
+} from './destructive';
 import { idempotencyKeySchema, runIdempotent } from './idempotency';
 import type { WebMCPTool } from './modelContext';
 import { asOptStr, asStr, str, strEnum } from './schema';
@@ -188,6 +193,29 @@ export function createCommentTools(): WebMCPTool[] {
           committedCount: results.length,
           results,
         };
+      },
+    },
+    {
+      name: 'comment-delete',
+      description:
+        'Destructive: permanently deletes one comment. If it is the only comment in its thread, the empty comment thread is also deleted. Call only after the user explicitly confirms the exact comment deletion.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          commentId: str('The comment id to permanently delete.'),
+          confirmDelete: deletionConfirmationSchema(),
+        },
+        required: ['commentId', 'confirmDelete'],
+      },
+      async execute(input) {
+        assertWritable('deleting a comment');
+        requireAuthUser();
+        const commentId = asStr(input.commentId, 'commentId');
+        const comment = useBoundStore.getState().comment[commentId];
+        if (!comment) throw new Error(`Comment ${commentId} is not loaded.`);
+        requireDeletionConfirmation(input.confirmDelete);
+        await dbDeleteComment(commentId, comment.commentGroupId);
+        return { ok: true, deletedCommentId: commentId };
       },
     },
     {

--- a/src/webmcp/destructive.ts
+++ b/src/webmcp/destructive.ts
@@ -1,0 +1,17 @@
+/** Guardrail shared by destructive WebMCP tools. */
+export function deletionConfirmationSchema(): Record<string, unknown> {
+  return {
+    type: 'string',
+    enum: ['DELETE'],
+    description:
+      'Required destructive-action confirmation. Set to DELETE only after the user has explicitly confirmed this permanent deletion.',
+  };
+}
+
+export function requireDeletionConfirmation(value: unknown): void {
+  if (value !== 'DELETE') {
+    throw new Error(
+      'Deletion requires confirmDelete: "DELETE" after explicit user confirmation.',
+    );
+  }
+}

--- a/src/webmcp/expense.tools.ts
+++ b/src/webmcp/expense.tools.ts
@@ -135,6 +135,162 @@ export function createExpenseTools(): WebMCPTool[] {
       },
     },
     {
+      name: 'expense-create-many',
+      description:
+        'Creates up to 50 expenses in one trip, for example when importing receipts or a day of cash spending. Every item is validated before the first write. Writes are ordered and non-atomic; per-item idempotency keys make retrying safe.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          tripId: str('Trip id applied to expenses that omit tripId.'),
+          expenses: {
+            type: 'array',
+            minItems: 1,
+            maxItems: 50,
+            description: 'Ordered expenses to create.',
+            items: {
+              type: 'object',
+              properties: {
+                idempotencyKey: idempotencyKeySchema(),
+                title: str('Expense title.'),
+                amount: num('Amount spent (numeric).'),
+                currency: str('ISO 4217 currency code (e.g. JPY).'),
+                currencyConversionFactor: num(
+                  'Optional conversion factor from origin currency to expense currency. Provide together with amountInOriginCurrency.',
+                ),
+                amountInOriginCurrency: num(
+                  'Optional amount in the trip origin currency. Provide together with currencyConversionFactor.',
+                ),
+                description: str('Optional description.'),
+                timestampIncurred: epochOrIso(
+                  'Optional date incurred (ISO-8601 or epoch ms).',
+                ),
+                timeZoneIncurred: str(
+                  'Optional IANA time zone where it was incurred.',
+                ),
+              },
+              required: ['title', 'amount'],
+            },
+          },
+        },
+        required: ['expenses'],
+      },
+      async execute(input) {
+        assertWritable('creating expenses');
+        requireAuthUser();
+        if (
+          !Array.isArray(input.expenses) ||
+          input.expenses.length < 1 ||
+          input.expenses.length > 50
+        ) {
+          throw new Error('expenses must contain between 1 and 50 items');
+        }
+        const tripId = resolveTripId(input.tripId);
+        requireLoadedTrip(tripId);
+        const trip = useBoundStore.getState().trip[tripId];
+        const items = input.expenses.map((item, index) => {
+          if (!item || typeof item !== 'object')
+            throw new Error(`expenses[${index}] must be an object`);
+          const merged: Record<string, unknown> = {
+            tripId,
+            ...(item as Record<string, unknown>),
+          };
+          const amount = asOptNum(merged.amount, 'amount');
+          if (amount === undefined || amount === null)
+            throw new Error('amount is required and must be a number');
+          const currency =
+            (merged.currency as string | undefined)?.toUpperCase() ??
+            trip.currency;
+          resolveExpenseConversion({
+            amount,
+            currency,
+            originCurrency: trip.originCurrency,
+            currencyConversionFactor: asOptNum(
+              merged.currencyConversionFactor,
+              'currencyConversionFactor',
+            ),
+            amountInOriginCurrency: asOptNum(
+              merged.amountInOriginCurrency,
+              'amountInOriginCurrency',
+            ),
+          });
+          asStr(merged.title, 'title');
+          toEpochMs(merged.timestampIncurred, 'timestampIncurred');
+          return merged;
+        });
+        const results: Array<Record<string, unknown>> = [];
+        for (let index = 0; index < items.length; index++) {
+          try {
+            const item = items[index];
+            const amount = asOptNum(item.amount, 'amount');
+            if (amount === undefined || amount === null) {
+              throw new Error('amount is required and must be a number');
+            }
+            const currency =
+              (item.currency as string | undefined)?.toUpperCase() ??
+              trip.currency;
+            const conversion = resolveExpenseConversion({
+              amount,
+              currency,
+              originCurrency: trip.originCurrency,
+              currencyConversionFactor: asOptNum(
+                item.currencyConversionFactor,
+                'currencyConversionFactor',
+              ),
+              amountInOriginCurrency: asOptNum(
+                item.amountInOriginCurrency,
+                'amountInOriginCurrency',
+              ),
+            });
+            results.push(
+              await runIdempotent(
+                'expense-create',
+                tripId,
+                item.idempotencyKey,
+                item,
+                async () => {
+                  const result = await dbAddExpense(
+                    {
+                      title: asStr(item.title, 'title'),
+                      description:
+                        asOptStr(item.description, 'description') ?? '',
+                      timestampIncurred:
+                        toEpochMs(
+                          item.timestampIncurred,
+                          'timestampIncurred',
+                        ) ?? Date.now(),
+                      currency,
+                      amount,
+                      ...conversion,
+                      timeZoneIncurred:
+                        asOptStr(item.timeZoneIncurred, 'timeZoneIncurred') ??
+                        null,
+                    },
+                    { tripId },
+                  );
+                  return { ok: true, id: result.id, expenseId: result.id };
+                },
+              ),
+            );
+          } catch (error) {
+            return {
+              ok: false,
+              atomic: false,
+              committedCount: results.length,
+              failedIndex: index,
+              results,
+              error: error instanceof Error ? error.message : String(error),
+            };
+          }
+        }
+        return {
+          ok: true,
+          atomic: false,
+          committedCount: results.length,
+          results,
+        };
+      },
+    },
+    {
       name: 'expense-get',
       description: 'Returns an expense from the locally loaded state by id.',
       inputSchema: {

--- a/src/webmcp/expense.tools.ts
+++ b/src/webmcp/expense.tools.ts
@@ -1,7 +1,11 @@
 import { assertWritable } from '../data/backendConfig';
 import { useBoundStore } from '../data/store';
-import { dbAddExpense, dbUpdateExpense } from '../Expense/db';
+import { dbAddExpense, dbDeleteExpense, dbUpdateExpense } from '../Expense/db';
 import { requireAuthUser, requireLoadedTrip, resolveTripId } from './context';
+import {
+  deletionConfirmationSchema,
+  requireDeletionConfirmation,
+} from './destructive';
 import { idempotencyKeySchema, runIdempotent } from './idempotency';
 import type { WebMCPTool } from './modelContext';
 import {
@@ -288,6 +292,29 @@ export function createExpenseTools(): WebMCPTool[] {
           committedCount: results.length,
           results,
         };
+      },
+    },
+    {
+      name: 'expense-delete',
+      description:
+        'Destructive: permanently deletes one expense from the trip. Call only after the user explicitly confirms the exact expense deletion.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          expenseId: str('The expense id to permanently delete.'),
+          confirmDelete: deletionConfirmationSchema(),
+        },
+        required: ['expenseId', 'confirmDelete'],
+      },
+      async execute(input) {
+        assertWritable('deleting an expense');
+        requireAuthUser();
+        const expenseId = asStr(input.expenseId, 'expenseId');
+        if (!useBoundStore.getState().expense[expenseId])
+          throw new Error(`Expense ${expenseId} is not loaded.`);
+        requireDeletionConfirmation(input.confirmDelete);
+        await dbDeleteExpense(expenseId);
+        return { ok: true, deletedExpenseId: expenseId };
       },
     },
     {

--- a/src/webmcp/macroplan.tools.ts
+++ b/src/webmcp/macroplan.tools.ts
@@ -1,7 +1,15 @@
 import { assertWritable } from '../data/backendConfig';
 import { useBoundStore } from '../data/store';
-import { dbAddMacroplan, dbUpdateMacroplan } from '../Macroplan/db';
+import {
+  dbAddMacroplan,
+  dbDeleteMacroplan,
+  dbUpdateMacroplan,
+} from '../Macroplan/db';
 import { requireAuthUser, requireLoadedTrip, resolveTripId } from './context';
+import {
+  deletionConfirmationSchema,
+  requireDeletionConfirmation,
+} from './destructive';
 import { idempotencyKeySchema, runIdempotent } from './idempotency';
 import type { WebMCPTool } from './modelContext';
 import { asOptStr, asStr, str } from './schema';
@@ -151,6 +159,29 @@ export function createMacroplanTools(): WebMCPTool[] {
           committedCount: results.length,
           results,
         };
+      },
+    },
+    {
+      name: 'day-plan-delete',
+      description:
+        'Destructive: permanently deletes one day plan. Call only after the user explicitly confirms the exact day-plan deletion.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          dayPlanId: str('The day-plan id to permanently delete.'),
+          confirmDelete: deletionConfirmationSchema(),
+        },
+        required: ['dayPlanId', 'confirmDelete'],
+      },
+      async execute(input) {
+        assertWritable('deleting a day plan');
+        requireAuthUser();
+        const dayPlanId = asStr(input.dayPlanId, 'dayPlanId');
+        if (!useBoundStore.getState().macroplan[dayPlanId])
+          throw new Error(`Day plan ${dayPlanId} is not loaded.`);
+        requireDeletionConfirmation(input.confirmDelete);
+        await dbDeleteMacroplan(dayPlanId);
+        return { ok: true, deletedDayPlanId: dayPlanId };
       },
     },
     {

--- a/src/webmcp/place.tools.ts
+++ b/src/webmcp/place.tools.ts
@@ -15,7 +15,7 @@ export function createPlaceTools(): WebMCPTool[] {
     {
       name: 'place-search',
       description:
-        'Searches for place candidates without modifying trip data. Returns canonical labels, WGS84 coordinates, recommended zoom, and a copy-ready `place` object. Ambiguous results are never chosen automatically; select one candidate and pass candidate.place verbatim to an activity or accommodation tool.',
+        'Searches for place candidates without modifying trip data. Returns canonical labels, WGS84 coordinates, recommended zoom, and a copy-ready `place` object. Ambiguous results are never chosen automatically; select one candidate and pass candidate.place verbatim to an activity or accommodation tool. If no suitable candidate is found or the result remains ambiguous, search Google Maps to identify and verify the place coordinates before writing.',
       inputSchema: {
         type: 'object',
         properties: {
@@ -78,8 +78,10 @@ export function createPlaceTools(): WebMCPTool[] {
           candidates,
           instruction:
             candidates.length === 0
-              ? 'No coordinates found; keep the missing-map state explicit.'
-              : 'Choose a candidate explicitly, then pass its `place` object verbatim to the `place` input of activity-create, activity-create-many, accommodation-create, or their update tools.',
+              ? 'No coordinates found. Search Google Maps to identify and verify the place coordinates; if that is still unavailable, keep the missing-map state explicit.'
+              : candidates.length === 1
+                ? 'Pass this candidate’s `place` object verbatim to the `place` input of activity-create, activity-create-many, accommodation-create, or their update tools.'
+                : 'Choose a candidate explicitly. If the candidates remain ambiguous, search Google Maps to identify and verify the place coordinates before writing.',
         };
       },
     },

--- a/src/webmcp/task.tools.ts
+++ b/src/webmcp/task.tools.ts
@@ -20,6 +20,150 @@ const VALID_STATUS: number[] = [
   TaskStatus.Cancelled,
 ];
 
+function taskListProperties() {
+  return {
+    tripId: str('Trip id. Defaults to the currently open trip.'),
+    idempotencyKey: idempotencyKeySchema(),
+    title: str('Task list title.'),
+  };
+}
+
+function taskProperties() {
+  return {
+    idempotencyKey: idempotencyKeySchema(),
+    title: str('Task title.'),
+    description: str('Optional description.'),
+    status: int(
+      'Task status: 0=todo, 1=in-progress, 2=done, 3=archived, 4=cancelled. Default 0.',
+    ),
+    dueAt: epochOrIso('Optional due time (ISO-8601 or epoch ms).'),
+  };
+}
+
+function requireBatch(
+  value: unknown,
+  name: string,
+): Array<Record<string, unknown>> {
+  if (!Array.isArray(value) || value.length < 1 || value.length > 50)
+    throw new Error(`${name} must contain between 1 and 50 items`);
+  return value.map((item, index) => {
+    if (!item || typeof item !== 'object')
+      throw new Error(`${name}[${index}] must be an object`);
+    return item as Record<string, unknown>;
+  });
+}
+
+function parseTaskList(input: Record<string, unknown>) {
+  const tripId = resolveTripId(input.tripId);
+  requireLoadedTrip(tripId);
+  return {
+    tripId,
+    data: { title: asStr(input.title, 'title'), index: 0, status: 0 },
+  };
+}
+
+async function createTaskList(input: Record<string, unknown>) {
+  const parsed = parseTaskList(input);
+  return runIdempotent(
+    'task-list-create',
+    parsed.tripId,
+    input.idempotencyKey,
+    input,
+    async () => {
+      const result = await dbAddTaskList(parsed.data, {
+        tripId: parsed.tripId,
+      });
+      return { ok: true, id: result.id, taskListId: result.id };
+    },
+  );
+}
+
+function parseTask(input: Record<string, unknown>, index?: number) {
+  const taskListId = asStr(input.taskListId, 'taskListId');
+  const existingList = useBoundStore.getState().taskList[taskListId];
+  if (!existingList) throw new Error(`Task list ${taskListId} is not loaded.`);
+  const status =
+    input.status === undefined ? TaskStatus.Todo : Number(input.status);
+  if (!VALID_STATUS.includes(status)) throw new Error('status is out of range');
+  const dueAt = toEpochMs(input.dueAt, 'dueAt');
+  return {
+    taskListId,
+    data: {
+      index: index ?? existingList.taskIds.length,
+      title: asStr(input.title, 'title'),
+      description: (input.description as string | undefined) ?? '',
+      status,
+      dueAt: dueAt ?? null,
+      completedAt: status === TaskStatus.Done ? Date.now() : null,
+    },
+  };
+}
+
+async function createTask(input: Record<string, unknown>, index?: number) {
+  const parsed = parseTask(input, index);
+  return runIdempotent(
+    'task-create',
+    parsed.taskListId,
+    input.idempotencyKey,
+    input,
+    async () => {
+      const result = await dbAddTask(parsed.data, {
+        taskListId: parsed.taskListId,
+      });
+      return { ok: true, id: result.id, taskId: result.id };
+    },
+  );
+}
+
+async function createTaskBatch(
+  taskListId: string,
+  tasks: Array<Record<string, unknown>>,
+) {
+  const list = useBoundStore.getState().taskList[taskListId];
+  if (!list) throw new Error(`Task list ${taskListId} is not loaded.`);
+  const firstIndex = list.taskIds.length;
+  const items = tasks.map((task) => ({ taskListId, ...task }));
+  items.forEach((item, index) => {
+    parseTask(item, firstIndex + index);
+  });
+  const results: Array<Record<string, unknown>> = [];
+  for (let index = 0; index < items.length; index++) {
+    try {
+      results.push(await createTask(items[index], firstIndex + index));
+    } catch (error) {
+      return {
+        ok: false,
+        atomic: false,
+        committedCount: results.length,
+        failedIndex: index,
+        results,
+        error: error instanceof Error ? error.message : String(error),
+      };
+    }
+  }
+  return { ok: true, atomic: false, committedCount: results.length, results };
+}
+
+async function createListBatch(items: Array<Record<string, unknown>>) {
+  items.forEach(parseTaskList);
+  const results: Array<Record<string, unknown>> = [];
+  for (let index = 0; index < items.length; index++) {
+    try {
+      results.push(await createTaskList(items[index]));
+    } catch (error) {
+      return {
+        ok: false,
+        atomic: false,
+        committedCount: results.length,
+        failedIndex: index,
+        results,
+        error: error instanceof Error ? error.message : String(error),
+      };
+    }
+  }
+  return { ok: true, atomic: false, committedCount: results.length, results };
+}
+
 export function createTaskTools(): WebMCPTool[] {
   return [
     {
@@ -28,32 +172,86 @@ export function createTaskTools(): WebMCPTool[] {
         'Creates a task list (column) within a trip. Tasks are created under a task-list id.',
       inputSchema: {
         type: 'object',
-        properties: {
-          tripId: str('Trip id. Defaults to the currently open trip.'),
-          idempotencyKey: idempotencyKeySchema(),
-          title: str('Task list title.'),
-        },
+        properties: taskListProperties(),
         required: ['title'],
       },
       async execute(input) {
         assertWritable('creating a task list');
         requireAuthUser();
-        const tripId = resolveTripId(input.tripId);
-        requireLoadedTrip(tripId);
-        const title = asStr(input.title, 'title');
-        return runIdempotent(
-          'task-list-create',
-          tripId,
-          input.idempotencyKey,
-          input,
-          async () => {
-            const result = await dbAddTaskList(
-              { title, index: 0, status: 0 },
-              { tripId },
-            );
-            return { ok: true, id: result.id, taskListId: result.id };
+        return createTaskList(input);
+      },
+    },
+    {
+      name: 'task-list-create-many',
+      description:
+        'Creates up to 50 task lists. Every item is validated before the first write. Writes are ordered and non-atomic; per-item idempotency keys make retrying safe.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          tripId: str('Trip id applied to lists that omit tripId.'),
+          taskLists: {
+            type: 'array',
+            minItems: 1,
+            maxItems: 50,
+            description: 'Ordered task lists to create.',
+            items: {
+              type: 'object',
+              properties: taskListProperties(),
+              required: ['title'],
+            },
           },
+        },
+        required: ['taskLists'],
+      },
+      async execute(input) {
+        assertWritable('creating task lists');
+        requireAuthUser();
+        return createListBatch(
+          requireBatch(input.taskLists, 'taskLists').map((item) => ({
+            tripId: input.tripId,
+            ...item,
+          })),
         );
+      },
+    },
+    {
+      name: 'task-list-create-with-tasks',
+      description:
+        'Creates one task list and up to 50 tasks in it. All input is validated before writing. Writes are ordered and non-atomic; use a list idempotencyKey and per-task idempotency keys to safely retry a partial result.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          ...taskListProperties(),
+          tasks: {
+            type: 'array',
+            minItems: 1,
+            maxItems: 50,
+            description: 'Tasks to create in the new list.',
+            items: {
+              type: 'object',
+              properties: taskProperties(),
+              required: ['title'],
+            },
+          },
+        },
+        required: ['title', 'tasks'],
+      },
+      async execute(input) {
+        assertWritable('creating a task list and tasks');
+        requireAuthUser();
+        const tasks = requireBatch(input.tasks, 'tasks');
+        parseTaskList(input);
+        tasks.forEach((task) => {
+          asStr(task.title, 'title');
+          const status =
+            task.status === undefined ? TaskStatus.Todo : Number(task.status);
+          if (!VALID_STATUS.includes(status))
+            throw new Error('status is out of range');
+          toEpochMs(task.dueAt, 'dueAt');
+        });
+        const list = await createTaskList(input);
+        const batch = await createTaskBatch(list.taskListId, tasks);
+        return { ...batch, taskListId: list.taskListId, taskList: list };
       },
     },
     {
@@ -91,45 +289,44 @@ export function createTaskTools(): WebMCPTool[] {
         type: 'object',
         properties: {
           taskListId: str('The task list id to add the task to.'),
-          idempotencyKey: idempotencyKeySchema(),
-          title: str('Task title.'),
-          description: str('Optional description.'),
-          status: int(
-            'Task status: 0=todo, 1=in-progress, 2=done, 3=archived, 4=cancelled. Default 0.',
-          ),
-          dueAt: epochOrIso('Optional due time (ISO-8601 or epoch ms).'),
+          ...taskProperties(),
         },
         required: ['taskListId', 'title'],
       },
       async execute(input) {
         assertWritable('creating a task');
         requireAuthUser();
-        const taskListId = asStr(input.taskListId, 'taskListId');
-        const existingList = useBoundStore.getState().taskList[taskListId];
-        if (!existingList)
-          throw new Error(`Task list ${taskListId} is not loaded.`);
-        const status =
-          input.status !== undefined ? Number(input.status) : TaskStatus.Todo;
-        if (!VALID_STATUS.includes(status))
-          throw new Error('status is out of range');
-        const dueAt = toEpochMs(input.dueAt, 'dueAt');
-        const data = {
-          index: existingList.taskIds.length,
-          title: asStr(input.title, 'title'),
-          description: (input.description as string | undefined) ?? '',
-          status,
-          dueAt: dueAt ?? null,
-          completedAt: status === TaskStatus.Done ? Date.now() : null,
-        };
-        return runIdempotent(
-          'task-create',
-          taskListId,
-          input.idempotencyKey,
-          input,
-          async () => {
-            const result = await dbAddTask(data, { taskListId });
-            return { ok: true, id: result.id, taskId: result.id };
+        return createTask(input);
+      },
+    },
+    {
+      name: 'task-create-many',
+      description:
+        'Creates up to 50 tasks in one existing task list. Every item is validated before the first write. Writes are ordered and non-atomic; per-item idempotency keys make retrying safe.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          taskListId: str('The task list id to add all tasks to.'),
+          tasks: {
+            type: 'array',
+            minItems: 1,
+            maxItems: 50,
+            description: 'Ordered tasks to create.',
+            items: {
+              type: 'object',
+              properties: taskProperties(),
+              required: ['title'],
+            },
           },
+        },
+        required: ['taskListId', 'tasks'],
+      },
+      async execute(input) {
+        assertWritable('creating tasks');
+        requireAuthUser();
+        return createTaskBatch(
+          asStr(input.taskListId, 'taskListId'),
+          requireBatch(input.tasks, 'tasks'),
         );
       },
     },
@@ -138,9 +335,7 @@ export function createTaskTools(): WebMCPTool[] {
       description: 'Returns a task from the locally loaded state by id.',
       inputSchema: {
         type: 'object',
-        properties: {
-          taskId: str('The task id.'),
-        },
+        properties: { taskId: str('The task id.') },
         required: ['taskId'],
       },
       annotations: { readOnlyHint: true },

--- a/src/webmcp/task.tools.ts
+++ b/src/webmcp/task.tools.ts
@@ -3,11 +3,17 @@ import { useBoundStore } from '../data/store';
 import {
   dbAddTask,
   dbAddTaskList,
+  dbDeleteTask,
+  dbDeleteTaskList,
   dbUpdateTask,
   dbUpdateTaskList,
 } from '../Task/db';
 import { TaskStatus } from '../Task/TaskStatus';
 import { requireAuthUser, requireLoadedTrip, resolveTripId } from './context';
+import {
+  deletionConfirmationSchema,
+  requireDeletionConfirmation,
+} from './destructive';
 import { idempotencyKeySchema, runIdempotent } from './idempotency';
 import type { WebMCPTool } from './modelContext';
 import { asStr, epochOrIso, int, str, toEpochMs } from './schema';
@@ -255,6 +261,29 @@ export function createTaskTools(): WebMCPTool[] {
       },
     },
     {
+      name: 'task-list-delete',
+      description:
+        'Destructive: permanently deletes one task list and every task in it. Call only after the user explicitly confirms the exact task-list deletion.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          taskListId: str('The task-list id to permanently delete.'),
+          confirmDelete: deletionConfirmationSchema(),
+        },
+        required: ['taskListId', 'confirmDelete'],
+      },
+      async execute(input) {
+        assertWritable('deleting a task list');
+        requireAuthUser();
+        const taskListId = asStr(input.taskListId, 'taskListId');
+        if (!useBoundStore.getState().taskList[taskListId])
+          throw new Error(`Task list ${taskListId} is not loaded.`);
+        requireDeletionConfirmation(input.confirmDelete);
+        await dbDeleteTaskList(taskListId);
+        return { ok: true, deletedTaskListId: taskListId };
+      },
+    },
+    {
       name: 'task-list-update',
       description: 'Renames a task list.',
       inputSchema: {
@@ -328,6 +357,29 @@ export function createTaskTools(): WebMCPTool[] {
           asStr(input.taskListId, 'taskListId'),
           requireBatch(input.tasks, 'tasks'),
         );
+      },
+    },
+    {
+      name: 'task-delete',
+      description:
+        'Destructive: permanently deletes one task. Call only after the user explicitly confirms the exact task deletion.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          taskId: str('The task id to permanently delete.'),
+          confirmDelete: deletionConfirmationSchema(),
+        },
+        required: ['taskId', 'confirmDelete'],
+      },
+      async execute(input) {
+        assertWritable('deleting a task');
+        requireAuthUser();
+        const taskId = asStr(input.taskId, 'taskId');
+        const task = useBoundStore.getState().task[taskId];
+        if (!task) throw new Error(`Task ${taskId} is not loaded.`);
+        requireDeletionConfirmation(input.confirmDelete);
+        await dbDeleteTask(taskId, task.taskListId);
+        return { ok: true, deletedTaskId: taskId };
       },
     },
     {

--- a/src/webmcp/tools.contract.test.ts
+++ b/src/webmcp/tools.contract.test.ts
@@ -4,9 +4,11 @@ vi.mock('../data/db', () => ({ db: {} }));
 
 import { createAccommodationTools } from './accommodation.tools';
 import { createActivityTools } from './activity.tools';
+import { createCommentTools } from './comment.tools';
 import { createExpenseTools, resolveExpenseConversion } from './expense.tools';
 import { createMacroplanTools } from './macroplan.tools';
 import { createPlaceTools } from './place.tools';
+import { createTaskTools } from './task.tools';
 import { createTripTools } from './trip.tools';
 
 function named(name: string, tools: ReturnType<typeof createTripTools>) {
@@ -103,5 +105,32 @@ describe('WebMCP reliability contracts', () => {
         amountInOriginCurrency: undefined,
       }),
     ).toThrow('must be provided together');
+  });
+
+  it('exposes bounded batch tools for repeated trip entities', () => {
+    const batches = [
+      [createTaskTools(), 'task-create-many', 'tasks'],
+      [createTaskTools(), 'task-list-create-many', 'taskLists'],
+      [createExpenseTools(), 'expense-create-many', 'expenses'],
+      [
+        createAccommodationTools(),
+        'accommodation-create-many',
+        'accommodations',
+      ],
+      [createCommentTools(), 'comment-add-many', 'comments'],
+    ] as const;
+    for (const [tools, name, field] of batches) {
+      const tool = tools.find((candidate) => candidate.name === name);
+      expect(tool?.inputSchema.properties[field]).toMatchObject({
+        type: 'array',
+        maxItems: 50,
+      });
+      expect(tool?.description).toContain('non-atomic');
+    }
+    expect(
+      createTaskTools().some(
+        (tool) => tool.name === 'task-list-create-with-tasks',
+      ),
+    ).toBe(true);
   });
 });

--- a/src/webmcp/tools.contract.test.ts
+++ b/src/webmcp/tools.contract.test.ts
@@ -54,6 +54,7 @@ describe('WebMCP reliability contracts', () => {
   it('returns a copy-ready place object for mapped writes', () => {
     const tool = named('place-search', createPlaceTools());
     expect(tool.description).toContain('candidate.place');
+    expect(tool.description).toContain('Google Maps');
   });
 
   it('exposes bounded day-plan batches with retry keys', () => {

--- a/src/webmcp/tools.contract.test.ts
+++ b/src/webmcp/tools.contract.test.ts
@@ -134,4 +134,24 @@ describe('WebMCP reliability contracts', () => {
       ),
     ).toBe(true);
   });
+
+  it('marks deletion tools as destructive and requires explicit confirmation', () => {
+    const deletionTools = [
+      [createActivityTools(), 'activity-delete'],
+      [createAccommodationTools(), 'accommodation-delete'],
+      [createExpenseTools(), 'expense-delete'],
+      [createTaskTools(), 'task-delete'],
+      [createTaskTools(), 'task-list-delete'],
+      [createMacroplanTools(), 'day-plan-delete'],
+      [createCommentTools(), 'comment-delete'],
+    ] as const;
+    for (const [tools, name] of deletionTools) {
+      const tool = tools.find((candidate) => candidate.name === name);
+      expect(tool?.description).toContain('Destructive:');
+      expect(tool?.inputSchema.required).toContain('confirmDelete');
+      expect(tool?.inputSchema.properties.confirmDelete).toMatchObject({
+        enum: ['DELETE'],
+      });
+    }
+  });
 });


### PR DESCRIPTION
## Summary
- add batch creation tools for tasks, task lists, expenses, accommodations, and comments
- add task-list-create-with-tasks convenience workflow
- cover batch tool contracts

## Tests
- pnpm typecheck
- pnpm vitest run src/webmcp/tools.contract.test.ts