### PR TITLE
Add trip archival with read-only archived trips

### DIFF
--- a/backend/app/Http/Controllers/Api/CommentController.php
+++ b/backend/app/Http/Controllers/Api/CommentController.php
@@ -101,7 +101,7 @@ class CommentController extends Controller
         $record = Comment::with('commentGroup.trip')->findOrFail($comment);
         $access = app(TripAccessService::class);
         abort_unless($request->user() && $access->canEdit($record->commentGroup->trip, $request->user()), 403);
-        $access->ensureContentWritable(Trip::query()->findOrFail($record->commentGroup->trip_id));
+        $access->ensureContentWritable(Trip::query()->findOrFail($record->commentGroup()->value('trip_id')));
         abort_unless($record->user_id === $request->user()->id || $access->canManage($record->commentGroup->trip, $request->user()), 403);
         $record->update($request->validate(['content' => ['required', 'string']]));
 
@@ -113,7 +113,7 @@ class CommentController extends Controller
         $record = Comment::with('commentGroup.trip')->findOrFail($comment);
         $access = app(TripAccessService::class);
         abort_unless($request->user() && $access->canEdit($record->commentGroup->trip, $request->user()), 403);
-        $access->ensureContentWritable(Trip::query()->findOrFail($record->commentGroup->trip_id));
+        $access->ensureContentWritable(Trip::query()->findOrFail($record->commentGroup()->value('trip_id')));
         abort_unless($record->user_id === $request->user()->id || $access->canManage($record->commentGroup->trip, $request->user()), 403);
         DB::transaction(function () use ($record): void {
             $group = $record->commentGroup;

--- a/backend/app/Http/Controllers/Api/CommentController.php
+++ b/backend/app/Http/Controllers/Api/CommentController.php
@@ -88,7 +88,9 @@ class CommentController extends Controller
     public function updateStatusById(Request $request, string $group): JsonResponse
     {
         $record = CommentGroup::with('trip')->findOrFail($group);
-        abort_unless($request->user() && app(TripAccessService::class)->canEdit($record->trip, $request->user()), 403);
+        $access = app(TripAccessService::class);
+        abort_unless($request->user() && $access->canEdit($record->trip, $request->user()), 403);
+        $access->ensureContentWritable(Trip::query()->findOrFail($record->trip_id));
         $record->update($request->validate(['status' => ['required', 'integer', 'in:0,1']]));
 
         return response()->json($record);
@@ -97,8 +99,10 @@ class CommentController extends Controller
     public function updateById(Request $request, string $comment): JsonResponse
     {
         $record = Comment::with('commentGroup.trip')->findOrFail($comment);
-        abort_unless($request->user() && app(TripAccessService::class)->canEdit($record->commentGroup->trip, $request->user()), 403);
-        abort_unless($record->user_id === $request->user()->id || app(TripAccessService::class)->canManage($record->commentGroup->trip, $request->user()), 403);
+        $access = app(TripAccessService::class);
+        abort_unless($request->user() && $access->canEdit($record->commentGroup->trip, $request->user()), 403);
+        $access->ensureContentWritable(Trip::query()->findOrFail($record->commentGroup->trip_id));
+        abort_unless($record->user_id === $request->user()->id || $access->canManage($record->commentGroup->trip, $request->user()), 403);
         $record->update($request->validate(['content' => ['required', 'string']]));
 
         return response()->json($record->fresh('user'));
@@ -107,8 +111,10 @@ class CommentController extends Controller
     public function destroyById(Request $request, string $comment): JsonResponse
     {
         $record = Comment::with('commentGroup.trip')->findOrFail($comment);
-        abort_unless($request->user() && app(TripAccessService::class)->canEdit($record->commentGroup->trip, $request->user()), 403);
-        abort_unless($record->user_id === $request->user()->id || app(TripAccessService::class)->canManage($record->commentGroup->trip, $request->user()), 403);
+        $access = app(TripAccessService::class);
+        abort_unless($request->user() && $access->canEdit($record->commentGroup->trip, $request->user()), 403);
+        $access->ensureContentWritable(Trip::query()->findOrFail($record->commentGroup->trip_id));
+        abort_unless($record->user_id === $request->user()->id || $access->canManage($record->commentGroup->trip, $request->user()), 403);
         DB::transaction(function () use ($record): void {
             $group = $record->commentGroup;
             $record->delete();

--- a/backend/app/Http/Controllers/Api/ContentController.php
+++ b/backend/app/Http/Controllers/Api/ContentController.php
@@ -23,7 +23,9 @@ class ContentController extends Controller
 {
     public function activityDestroy(Request $request, Activity $activity, TripAccessService $access): JsonResponse
     {
-        abort_unless($request->user() && $access->canEdit($this->tripFor($activity), $request->user()), 403);
+        $trip = $this->tripFor($activity);
+        abort_unless($request->user() && $access->canEdit($trip, $request->user()), 403);
+        $access->ensureContentWritable($trip);
         DB::transaction(function () use ($activity): void {
             $this->deleteRelatedComments('activity', $activity->id);
             $activity->delete();
@@ -37,6 +39,7 @@ class ContentController extends Controller
         $trip = $activity->trip;
         abort_unless($trip instanceof Trip, 404);
         abort_unless($request->user() && $access->canEdit($trip, $request->user()), 403);
+        $access->ensureContentWritable($trip);
         $this->validateActivityPlanning($request, $trip);
         $activity->fill($this->mapFields($request->except(['id', 'trip_id', 'created_at_ms', 'updated_at_ms'])));
         $activity->save();
@@ -47,6 +50,7 @@ class ContentController extends Controller
     public function activityBatchUpdate(Request $request, Trip $trip, TripAccessService $access): JsonResponse
     {
         abort_unless($request->user() && $access->canEdit($trip, $request->user()), 403);
+        $access->ensureContentWritable($trip);
         $updates = $request->validate([
             'activities' => ['required', 'array', 'max:1000'],
             'activities.*.id' => ['required', 'string'],
@@ -69,6 +73,7 @@ class ContentController extends Controller
     public function activityDragEnd(Request $request, Trip $trip, string $activity, TripAccessService $access): JsonResponse
     {
         abort_unless($request->user() && $access->canEdit($trip, $request->user()), 403);
+        $access->ensureContentWritable($trip);
         $record = $trip->activities()->whereKey($activity)->firstOrFail();
         $data = $request->validate(['timestampStart' => ['nullable', 'integer'], 'timestampEnd' => ['nullable', 'integer']]);
         $record->update([
@@ -83,6 +88,7 @@ class ContentController extends Controller
     public function activityDuplicate(Request $request, Trip $trip, string $activity, TripAccessService $access): JsonResponse
     {
         abort_unless($request->user() && $access->canEdit($trip, $request->user()), 403);
+        $access->ensureContentWritable($trip);
         $record = $trip->activities()->whereKey($activity)->firstOrFail();
         $data = $request->validate([
             'timestampStart' => ['nullable', 'integer'],
@@ -102,7 +108,9 @@ class ContentController extends Controller
 
     public function activityDragEndById(Request $request, Activity $activity, TripAccessService $access): JsonResponse
     {
-        abort_unless($request->user() && $access->canEdit($this->tripFor($activity), $request->user()), 403);
+        $trip = $this->tripFor($activity);
+        abort_unless($request->user() && $access->canEdit($trip, $request->user()), 403);
+        $access->ensureContentWritable($trip);
         $data = $request->validate(['timestampStart' => ['nullable', 'integer'], 'timestampEnd' => ['nullable', 'integer']]);
         $activity->update(['timestamp_start_ms' => $data['timestampStart'] ?? null, 'timestamp_end_ms' => $data['timestampEnd'] ?? null, 'flags' => ((int) $activity->flags) & ~1]);
 
@@ -111,7 +119,9 @@ class ContentController extends Controller
 
     public function activityDuplicateById(Request $request, Activity $activity, TripAccessService $access): JsonResponse
     {
-        abort_unless($request->user() && $access->canEdit($this->tripFor($activity), $request->user()), 403);
+        $trip = $this->tripFor($activity);
+        abort_unless($request->user() && $access->canEdit($trip, $request->user()), 403);
+        $access->ensureContentWritable($trip);
         $data = $request->validate([
             'timestampStart' => ['nullable', 'integer'],
             'timestampEnd' => ['nullable', 'integer'],
@@ -132,6 +142,7 @@ class ContentController extends Controller
         $record = $this->recordById($entity, $entityId);
         $trip = $this->tripFor($record);
         abort_unless($request->user() && $access->canEdit($trip, $request->user()), 403);
+        $access->ensureContentWritable($trip);
         if ($record instanceof Activity) {
             $this->validateActivityPlanning($request, $trip);
         }
@@ -144,7 +155,9 @@ class ContentController extends Controller
     public function byIdDestroy(Request $request, string $entity, string $entityId, TripAccessService $access): JsonResponse
     {
         $record = $this->recordById($entity, $entityId);
-        abort_unless($request->user() && $access->canEdit($this->tripFor($record), $request->user()), 403);
+        $trip = $this->tripFor($record);
+        abort_unless($request->user() && $access->canEdit($trip, $request->user()), 403);
+        $access->ensureContentWritable($trip);
         $this->deleteEntityDescGraph($record);
         $record->delete();
 

--- a/backend/app/Http/Controllers/Api/TaskController.php
+++ b/backend/app/Http/Controllers/Api/TaskController.php
@@ -176,7 +176,7 @@ class TaskController extends Controller
         $task->load('taskList.trip');
         $access = app(TripAccessService::class);
         abort_unless($access->canEdit($task->taskList->trip, $request->user()), 403);
-        $access->ensureContentWritable(Trip::query()->findOrFail($task->taskList->trip_id));
+        $access->ensureContentWritable(Trip::query()->findOrFail($task->taskList()->value('trip_id')));
         DB::transaction(function () use ($task): void {
             $this->deleteTaskComments($task->id);
             $task->delete();
@@ -244,7 +244,7 @@ class TaskController extends Controller
         $task->load('taskList.trip');
         $access = app(TripAccessService::class);
         abort_unless($access->canEdit($task->taskList->trip, $request->user()), 403);
-        $access->ensureContentWritable(Trip::query()->findOrFail($task->taskList->trip_id));
+        $access->ensureContentWritable(Trip::query()->findOrFail($task->taskList()->value('trip_id')));
         $data = $request->validate(['index' => ['required', 'integer']]);
         $task->update(['index' => $data['index']]);
 
@@ -257,7 +257,7 @@ class TaskController extends Controller
         $task->load('taskList.trip');
         $access = app(TripAccessService::class);
         abort_unless($access->canEdit($task->taskList->trip, $request->user()), 403);
-        $trip = Trip::query()->findOrFail($task->taskList->trip_id);
+        $trip = Trip::query()->findOrFail($task->taskList()->value('trip_id'));
         $access->ensureContentWritable($trip);
         $data = $request->validate(['toTaskListId' => ['required', 'string'], 'newIndex' => ['required', 'integer', 'min:0']]);
         $target = TaskList::query()->where('trip_id', $trip->id)->findOrFail($data['toTaskListId']);
@@ -272,7 +272,7 @@ class TaskController extends Controller
         $task->load('taskList.trip');
         $access = app(TripAccessService::class);
         abort_unless($access->canEdit($task->taskList->trip, $request->user()), 403);
-        $access->ensureContentWritable(Trip::query()->findOrFail($task->taskList->trip_id));
+        $access->ensureContentWritable(Trip::query()->findOrFail($task->taskList()->value('trip_id')));
         $data = $request->validate(['title' => ['sometimes', 'string', 'max:255'], 'description' => ['nullable', 'string'], 'index' => ['sometimes', 'integer'], 'status' => ['sometimes', 'integer'], 'dueAt' => ['nullable', 'integer'], 'completedAt' => ['nullable', 'integer']]);
         $updates = [];
         foreach (['title', 'description', 'index', 'status', 'dueAt', 'completedAt'] as $field) {

--- a/backend/app/Http/Controllers/Api/TaskController.php
+++ b/backend/app/Http/Controllers/Api/TaskController.php
@@ -64,6 +64,7 @@ class TaskController extends Controller
         $taskList->load('trip');
         $access = app(TripAccessService::class);
         abort_unless($access->canEdit($taskList->trip, $request->user()), 403);
+        $access->ensureContentWritable(Trip::query()->findOrFail($taskList->trip_id));
         $data = $request->validate([
             'title' => ['required', 'string', 'max:255'],
             'description' => ['nullable', 'string'],
@@ -162,6 +163,7 @@ class TaskController extends Controller
         $taskList->load('trip');
         $access = app(TripAccessService::class);
         abort_unless($access->canEdit($taskList->trip, $request->user()), 403);
+        $access->ensureContentWritable(Trip::query()->findOrFail($taskList->trip_id));
         $data = $request->validate(['title' => ['sometimes', 'string', 'max:255'], 'index' => ['sometimes', 'integer'], 'status' => ['sometimes', 'integer']]);
         $taskList->update($data);
 
@@ -174,6 +176,7 @@ class TaskController extends Controller
         $task->load('taskList.trip');
         $access = app(TripAccessService::class);
         abort_unless($access->canEdit($task->taskList->trip, $request->user()), 403);
+        $access->ensureContentWritable(Trip::query()->findOrFail($task->taskList->trip_id));
         DB::transaction(function () use ($task): void {
             $this->deleteTaskComments($task->id);
             $task->delete();
@@ -188,6 +191,7 @@ class TaskController extends Controller
         $taskList->load('trip');
         $access = app(TripAccessService::class);
         abort_unless($access->canEdit($taskList->trip, $request->user()), 403);
+        $access->ensureContentWritable(Trip::query()->findOrFail($taskList->trip_id));
         DB::transaction(function () use ($taskList): void {
             foreach ($taskList->tasks as $task) {
                 $this->deleteTaskComments($task->id);
@@ -240,6 +244,7 @@ class TaskController extends Controller
         $task->load('taskList.trip');
         $access = app(TripAccessService::class);
         abort_unless($access->canEdit($task->taskList->trip, $request->user()), 403);
+        $access->ensureContentWritable(Trip::query()->findOrFail($task->taskList->trip_id));
         $data = $request->validate(['index' => ['required', 'integer']]);
         $task->update(['index' => $data['index']]);
 
@@ -252,8 +257,10 @@ class TaskController extends Controller
         $task->load('taskList.trip');
         $access = app(TripAccessService::class);
         abort_unless($access->canEdit($task->taskList->trip, $request->user()), 403);
+        $trip = Trip::query()->findOrFail($task->taskList->trip_id);
+        $access->ensureContentWritable($trip);
         $data = $request->validate(['toTaskListId' => ['required', 'string'], 'newIndex' => ['required', 'integer', 'min:0']]);
-        $target = $task->taskList->trip->taskLists()->whereKey($data['toTaskListId'])->firstOrFail();
+        $target = TaskList::query()->where('trip_id', $trip->id)->findOrFail($data['toTaskListId']);
         $task->update(['task_list_id' => $target->id, 'index' => $data['newIndex']]);
 
         return response()->json($task->fresh());
@@ -265,6 +272,7 @@ class TaskController extends Controller
         $task->load('taskList.trip');
         $access = app(TripAccessService::class);
         abort_unless($access->canEdit($task->taskList->trip, $request->user()), 403);
+        $access->ensureContentWritable(Trip::query()->findOrFail($task->taskList->trip_id));
         $data = $request->validate(['title' => ['sometimes', 'string', 'max:255'], 'description' => ['nullable', 'string'], 'index' => ['sometimes', 'integer'], 'status' => ['sometimes', 'integer'], 'dueAt' => ['nullable', 'integer'], 'completedAt' => ['nullable', 'integer']]);
         $updates = [];
         foreach (['title', 'description', 'index', 'status', 'dueAt', 'completedAt'] as $field) {

--- a/backend/app/Http/Controllers/Api/TripController.php
+++ b/backend/app/Http/Controllers/Api/TripController.php
@@ -38,15 +38,26 @@ class TripController extends Controller
             ->where('trip_user.user_id', $userId)
             ->distinct();
 
-        if ($request->query('status') === 'active') {
+        $status = $request->query('status');
+        if ($status === 'archived') {
+            $query->whereNotNull('archived_at_ms');
+        } else {
+            $query->whereNull('archived_at_ms');
+        }
+
+        if ($status === 'active') {
             $query->where('timestamp_end_ms', '>=', $now);
-        } elseif ($request->query('status') === 'past') {
+        } elseif ($status === 'past') {
             $query->where('timestamp_end_ms', '<', $now);
         }
 
-        $trips = $query->orderBy('timestamp_end_ms', 'desc')
-            ->orderBy('trips.id') // deterministic tiebreak for equal timestamp_end_ms
-            ->cursorPaginate(min($request->integer('limit', 50), 100));
+        if ($status === 'archived') {
+            $query->orderByDesc('archived_at_ms')->orderBy('trips.id');
+        } else {
+            $query->orderBy('timestamp_end_ms', 'desc')->orderBy('trips.id'); // deterministic tiebreak for equal timestamp_end_ms
+        }
+
+        $trips = $query->cursorPaginate(min($request->integer('limit', 50), 100));
 
         return response()->json([
             'data' => collect($trips->items())->map(fn (Trip $trip): array => [
@@ -55,6 +66,7 @@ class TripController extends Controller
                 'timestampStart' => $trip->timestamp_start_ms,
                 'timestampEnd' => $trip->timestamp_end_ms,
                 'timeZone' => $trip->timezone,
+                'archivedAt' => $trip->archived_at_ms,
                 'createdAt' => $trip->created_at_ms,
                 'lastUpdatedAt' => $trip->updated_at_ms,
             ])->values(),
@@ -81,6 +93,7 @@ class TripController extends Controller
             'timestampStart' => $trip->timestamp_start_ms,
             'timestampEnd' => $trip->timestamp_end_ms,
             'timeZone' => $trip->timezone,
+            'archivedAt' => $trip->archived_at_ms,
             'createdAt' => $trip->created_at_ms,
             'lastUpdatedAt' => $trip->updated_at_ms,
             'ownerHandle' => $trip->users->first()?->handle,
@@ -169,6 +182,14 @@ class TripController extends Controller
         $trip->update(['sharing_level' => $request->validate(['sharingLevel' => ['required', 'integer', 'in:0,2,3']])['sharingLevel']]);
 
         return response()->json($this->serializeTrip($trip->fresh()));
+    }
+
+    public function archive(Request $request, Trip $trip): JsonResponse
+    {
+        $archived = $request->validate(['archived' => ['required', 'boolean']])['archived'];
+        $trip->update(['archived_at_ms' => $archived ? ($trip->archived_at_ms ?? $this->nowMs()) : null]);
+
+        return response()->json($this->serializeTrip($trip->fresh('users')));
     }
 
     public function sections(Request $request, Trip $trip): JsonResponse
@@ -327,6 +348,7 @@ class TripController extends Controller
             'originCurrency' => $trip->origin_currency,
             'originRegion' => $trip->origin_region,
             'originTimeZone' => $trip->origin_timezone,
+            'archivedAt' => $trip->archived_at_ms,
             'sharingLevel' => $trip->sharing_level,
             'publicShowExpenses' => $trip->public_show_expenses,
             'publicShowTasks' => $trip->public_show_tasks,

--- a/backend/app/Http/Middleware/EnsureTripContentWritable.php
+++ b/backend/app/Http/Middleware/EnsureTripContentWritable.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use App\Models\Trip;
+use App\Services\TripAccessService;
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class EnsureTripContentWritable
+{
+    public function __construct(private readonly TripAccessService $access) {}
+
+    public function handle(Request $request, Closure $next): Response
+    {
+        /** @var Trip $trip */
+        $trip = $request->route('trip');
+        $this->access->ensureContentWritable($trip);
+
+        return $next($request);
+    }
+}

--- a/backend/app/Models/Trip.php
+++ b/backend/app/Models/Trip.php
@@ -22,6 +22,7 @@ class Trip extends Model
     protected function casts(): array
     {
         return [
+            'archived_at_ms' => 'integer',
             // Nullable section-visibility flags: null = visible, 0/'0' = hidden.
             'public_show_expenses' => 'boolean',
             'public_show_tasks' => 'boolean',

--- a/backend/app/Services/TripAccessService.php
+++ b/backend/app/Services/TripAccessService.php
@@ -32,4 +32,9 @@ class TripAccessService
     {
         return $this->role($trip, $user) === 0;
     }
+
+    public function ensureContentWritable(Trip $trip): void
+    {
+        abort_if($trip->archived_at_ms !== null, 409, 'Archived trips are read-only.');
+    }
 }

--- a/backend/bootstrap/app.php
+++ b/backend/bootstrap/app.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Http\Middleware\AuthorizeTripAccess;
+use App\Http\Middleware\EnsureTripContentWritable;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
@@ -19,6 +20,7 @@ return Application::configure(basePath: dirname(__DIR__))
         // All authenticated mutations remain CSRF-protected.
         $middleware->alias([
             'trip.access' => AuthorizeTripAccess::class,
+            'trip.writable' => EnsureTripContentWritable::class,
         ]);
 
         // The frontend models empty strings as "" (matching InstantDB's required

--- a/backend/database/migrations/2026_08_30_000001_add_archived_at_to_trips_table.php
+++ b/backend/database/migrations/2026_08_30_000001_add_archived_at_to_trips_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('trips', function (Blueprint $table): void {
+            $table->bigInteger('archived_at_ms')->nullable()->after('updated_at_ms');
+            $table->index(['archived_at_ms', 'id']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('trips', function (Blueprint $table): void {
+            $table->dropIndex(['archived_at_ms', 'id']);
+            $table->dropColumn('archived_at_ms');
+        });
+    }
+};

--- a/backend/phpstan-baseline.neon
+++ b/backend/phpstan-baseline.neon
@@ -201,7 +201,7 @@ parameters:
 		-
 			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model\:\:\$trip\.$#'
 			identifier: property.notFound
-			count: 5
+			count: 4
 			path: app/Http/Controllers/Api/TaskController.php
 
 		-

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -60,32 +60,34 @@ Route::middleware('web')->group(function (): void {
         ->middleware(['auth', 'trip.access:manage']);
 
     Route::put('/trips/{trip}', [TripController::class, 'update'])
-        ->middleware(['auth', 'trip.access:edit']);
+        ->middleware(['auth', 'trip.access:edit', 'trip.writable']);
     Route::post('/trips/{trip}/duplicate', [TripController::class, 'duplicate'])
-        ->middleware(['auth', 'trip.access:edit']);
+        ->middleware(['auth', 'trip.access:edit', 'trip.writable']);
+    Route::patch('/trips/{trip}/archive', [TripController::class, 'archive'])
+        ->middleware(['auth', 'trip.access:manage']);
     Route::patch('/trips/{trip}/sharing', [TripController::class, 'sharing'])
         ->middleware(['auth', 'trip.access:manage']);
     Route::patch('/trips/{trip}/sections', [TripController::class, 'sections'])
-        ->middleware(['auth', 'trip.access:manage']);
+        ->middleware(['auth', 'trip.access:manage', 'trip.writable']);
 
     Route::get('/trips/{trip}/{entity}', [ContentController::class, 'index'])
         ->whereIn('entity', ['activities', 'accommodations', 'macroplans', 'expenses'])
         ->middleware('trip.access:view');
     Route::patch('/trips/{trip}/activities/batch', [ContentController::class, 'activityBatchUpdate'])
-        ->middleware(['auth', 'trip.access:edit']);
+        ->middleware(['auth', 'trip.access:edit', 'trip.writable']);
     Route::post('/trips/{trip}/{entity}', [ContentController::class, 'store'])
         ->whereIn('entity', ['activities', 'accommodations', 'macroplans', 'expenses'])
-        ->middleware(['auth', 'trip.access:edit']);
+        ->middleware(['auth', 'trip.access:edit', 'trip.writable']);
     Route::put('/trips/{trip}/{entity}/{entityId}', [ContentController::class, 'update'])
         ->whereIn('entity', ['activities', 'accommodations', 'macroplans', 'expenses'])
-        ->middleware(['auth', 'trip.access:edit']);
+        ->middleware(['auth', 'trip.access:edit', 'trip.writable']);
     Route::delete('/trips/{trip}/{entity}/{entityId}', [ContentController::class, 'destroy'])
         ->whereIn('entity', ['activities', 'accommodations', 'macroplans', 'expenses'])
-        ->middleware(['auth', 'trip.access:edit']);
+        ->middleware(['auth', 'trip.access:edit', 'trip.writable']);
     Route::post('/trips/{trip}/activities/{activity}/drag-end', [ContentController::class, 'activityDragEnd'])
-        ->middleware(['auth', 'trip.access:edit']);
+        ->middleware(['auth', 'trip.access:edit', 'trip.writable']);
     Route::post('/trips/{trip}/activities/{activity}/duplicate', [ContentController::class, 'activityDuplicate'])
-        ->middleware(['auth', 'trip.access:edit']);
+        ->middleware(['auth', 'trip.access:edit', 'trip.writable']);
 
     Route::post('/task-lists/{taskList}/tasks', [TaskController::class, 'storeTaskById'])
         ->middleware('auth');
@@ -103,23 +105,23 @@ Route::middleware('web')->group(function (): void {
         ->middleware('auth');
 
     Route::post('/trips/{trip}/task-lists', [TaskController::class, 'storeList'])
-        ->middleware(['auth', 'trip.access:edit']);
+        ->middleware(['auth', 'trip.access:edit', 'trip.writable']);
     Route::put('/trips/{trip}/task-lists/{taskList}', [TaskController::class, 'updateList'])
-        ->middleware(['auth', 'trip.access:edit']);
+        ->middleware(['auth', 'trip.access:edit', 'trip.writable']);
     Route::delete('/trips/{trip}/task-lists/{taskList}', [TaskController::class, 'destroyList'])
-        ->middleware(['auth', 'trip.access:edit']);
+        ->middleware(['auth', 'trip.access:edit', 'trip.writable']);
     Route::post('/trips/{trip}/task-lists/{taskList}/tasks', [TaskController::class, 'storeTask'])
-        ->middleware(['auth', 'trip.access:edit']);
+        ->middleware(['auth', 'trip.access:edit', 'trip.writable']);
     Route::put('/trips/{trip}/task-lists/{taskList}/tasks/{task}', [TaskController::class, 'updateTask'])
-        ->middleware(['auth', 'trip.access:edit']);
+        ->middleware(['auth', 'trip.access:edit', 'trip.writable']);
     Route::delete('/trips/{trip}/task-lists/{taskList}/tasks/{task}', [TaskController::class, 'destroyTask'])
-        ->middleware(['auth', 'trip.access:edit']);
+        ->middleware(['auth', 'trip.access:edit', 'trip.writable']);
     Route::patch('/trips/{trip}/tasks/reorder', [TaskController::class, 'reorderTasks'])
-        ->middleware(['auth', 'trip.access:edit']);
+        ->middleware(['auth', 'trip.access:edit', 'trip.writable']);
     Route::patch('/trips/{trip}/task-lists/reorder', [TaskController::class, 'reorderLists'])
-        ->middleware(['auth', 'trip.access:edit']);
+        ->middleware(['auth', 'trip.access:edit', 'trip.writable']);
     Route::post('/trips/{trip}/tasks/{task}/move', [TaskController::class, 'moveTask'])
-        ->middleware(['auth', 'trip.access:edit']);
+        ->middleware(['auth', 'trip.access:edit', 'trip.writable']);
 
     Route::patch('/comment-groups/{group}/status', [CommentController::class, 'updateStatusById'])
         ->middleware('auth');
@@ -129,13 +131,13 @@ Route::middleware('web')->group(function (): void {
         ->middleware('auth');
 
     Route::post('/trips/{trip}/comment-groups', [CommentController::class, 'store'])
-        ->middleware(['auth', 'trip.access:edit']);
+        ->middleware(['auth', 'trip.access:edit', 'trip.writable']);
     Route::patch('/trips/{trip}/comment-groups/{group}/status', [CommentController::class, 'updateStatus'])
-        ->middleware(['auth', 'trip.access:edit']);
+        ->middleware(['auth', 'trip.access:edit', 'trip.writable']);
     Route::put('/trips/{trip}/comment-groups/{group}/comments/{comment}', [CommentController::class, 'update'])
-        ->middleware(['auth', 'trip.access:edit']);
+        ->middleware(['auth', 'trip.access:edit', 'trip.writable']);
     Route::delete('/trips/{trip}/comment-groups/{group}/comments/{comment}', [CommentController::class, 'destroy'])
-        ->middleware(['auth', 'trip.access:edit']);
+        ->middleware(['auth', 'trip.access:edit', 'trip.writable']);
 
     Route::get('/users/me', [UserController::class, 'me'])->middleware('auth');
     Route::post('/users/check-email', [UserController::class, 'checkEmail']);

--- a/backend/tests/Feature/ApiMigrationTest.php
+++ b/backend/tests/Feature/ApiMigrationTest.php
@@ -199,6 +199,63 @@ class ApiMigrationTest extends TestCase
         $this->assertDatabaseHas('trips', ['title' => 'Copy', 'sharing_level' => 0]);
     }
 
+    public function test_owner_can_archive_and_unarchive_a_trip(): void
+    {
+        $owner = $this->user();
+        $editor = $this->user();
+        $trip = Trip::create([
+            'id' => (string) Str::uuid(), 'title' => 'Archive me', 'region' => 'JP', 'currency' => 'JPY',
+            'timezone' => 'Asia/Tokyo', 'timestamp_start_ms' => 1000, 'timestamp_end_ms' => 2000,
+            'sharing_level' => 0,
+        ]);
+        $trip->users()->attach($owner->id, ['id' => (string) Str::uuid(), 'role' => 0, 'created_at_ms' => 1, 'updated_at_ms' => 1]);
+        $trip->users()->attach($editor->id, ['id' => (string) Str::uuid(), 'role' => 1, 'created_at_ms' => 1, 'updated_at_ms' => 1]);
+
+        $archivedAt = $this->actingAs($owner)->patchJson('/api/trips/' . $trip->id . '/archive', ['archived' => true])
+            ->assertOk()->json('archivedAt');
+        $this->assertIsInt($archivedAt);
+        $this->actingAs($owner)->patchJson('/api/trips/' . $trip->id . '/archive', ['archived' => true])
+            ->assertOk()->assertJsonPath('archivedAt', $archivedAt);
+        $this->actingAs($editor)->patchJson('/api/trips/' . $trip->id . '/archive', ['archived' => false])
+            ->assertForbidden();
+
+        $this->actingAs($owner)->getJson('/api/trips?status=active&now=0')
+            ->assertOk()->assertJsonCount(0, 'data');
+        $this->actingAs($owner)->getJson('/api/trips?status=archived')
+            ->assertOk()->assertJsonCount(1, 'data')->assertJsonPath('data.0.archivedAt', $archivedAt);
+
+        $this->actingAs($owner)->patchJson('/api/trips/' . $trip->id . '/archive', ['archived' => false])
+            ->assertOk()->assertJsonPath('archivedAt', null);
+        $this->actingAs($owner)->getJson('/api/trips?status=active&now=0')
+            ->assertOk()->assertJsonCount(1, 'data')->assertJsonPath('data.0.archivedAt', null);
+    }
+
+    public function test_archived_trip_locks_content_but_allows_sharing_and_deletion(): void
+    {
+        $owner = $this->user();
+        $trip = Trip::create([
+            'id' => (string) Str::uuid(), 'title' => 'Read-only', 'region' => 'JP', 'currency' => 'JPY',
+            'timezone' => 'Asia/Tokyo', 'timestamp_start_ms' => 1000, 'timestamp_end_ms' => 2000,
+            'sharing_level' => 0, 'archived_at_ms' => 3000,
+        ]);
+        $trip->users()->attach($owner->id, ['id' => (string) Str::uuid(), 'role' => 0, 'created_at_ms' => 1, 'updated_at_ms' => 1]);
+        $activity = $trip->activities()->create(['id' => (string) Str::uuid(), 'title' => 'Existing', 'location' => '', 'description' => '']);
+
+        $this->actingAs($owner)->putJson('/api/trips/' . $trip->id, ['title' => 'Blocked'])
+            ->assertConflict();
+        $this->actingAs($owner)->postJson('/api/trips/' . $trip->id . '/activities', [])
+            ->assertConflict();
+        $this->actingAs($owner)->putJson('/api/activities/' . $activity->id, ['title' => 'Blocked'])
+            ->assertConflict();
+        $this->actingAs($owner)->postJson('/api/trips/' . $trip->id . '/duplicate', [
+            'title' => 'Blocked copy', 'startDateMs' => 3000, 'endDateMs' => 4000,
+        ])->assertConflict();
+
+        $this->actingAs($owner)->patchJson('/api/trips/' . $trip->id . '/sharing', ['sharingLevel' => 2])
+            ->assertOk()->assertJsonPath('sharingLevel', 2);
+        $this->actingAs($owner)->deleteJson('/api/trips/' . $trip->id)->assertOk();
+    }
+
     public function test_sync_returns_delete_tombstone_after_entity_deletion(): void
     {
         $user = $this->user();

--- a/backend/tests/Feature/TripArchivalTest.php
+++ b/backend/tests/Feature/TripArchivalTest.php
@@ -1,0 +1,186 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Activity;
+use App\Models\Trip;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+class TripArchivalTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function user(): User
+    {
+        return User::create([
+            'id' => (string) Str::uuid(),
+            'handle' => 'user_' . Str::lower(Str::random(8)),
+            'email' => Str::lower(Str::random(8)) . '@example.com',
+            'password_hash' => password_hash('password', PASSWORD_DEFAULT),
+            'activated' => true,
+        ]);
+    }
+
+    private function trip(User $owner, array $overrides = []): Trip
+    {
+        $trip = Trip::create(array_merge([
+            'id' => (string) Str::uuid(),
+            'title' => 'Archive test trip',
+            'region' => 'JP',
+            'currency' => 'JPY',
+            'origin_currency' => 'USD',
+            'timezone' => 'Asia/Tokyo',
+            'timestamp_start_ms' => 100,
+            'timestamp_end_ms' => 200,
+            'sharing_level' => 0,
+        ], $overrides));
+        $trip->users()->attach($owner->id, [
+            'id' => (string) Str::uuid(),
+            'role' => 0,
+            'created_at_ms' => 1,
+            'updated_at_ms' => 1,
+        ]);
+
+        return $trip;
+    }
+
+    private function addMember(Trip $trip, User $user, int $role): void
+    {
+        $trip->users()->attach($user->id, [
+            'id' => (string) Str::uuid(),
+            'role' => $role,
+            'created_at_ms' => 1,
+            'updated_at_ms' => 1,
+        ]);
+    }
+
+    public function test_owner_can_archive_and_unarchive_a_trip_idempotently(): void
+    {
+        $owner = $this->user();
+        $trip = $this->trip($owner);
+
+        $archived = $this->actingAs($owner)
+            ->patchJson('/api/trips/' . $trip->id . '/archive', ['archived' => true])
+            ->assertOk()
+            ->assertJsonPath('id', $trip->id)
+            ->json('archivedAt');
+        $this->assertIsInt($archived);
+        $this->assertDatabaseHas('trips', ['id' => $trip->id, 'archived_at_ms' => $archived]);
+
+        $this->actingAs($owner)
+            ->patchJson('/api/trips/' . $trip->id . '/archive', ['archived' => true])
+            ->assertOk()
+            ->assertJsonPath('archivedAt', $archived);
+
+        $this->actingAs($owner)
+            ->patchJson('/api/trips/' . $trip->id . '/archive', ['archived' => false])
+            ->assertOk()
+            ->assertJsonPath('archivedAt', null);
+        $this->assertDatabaseHas('trips', ['id' => $trip->id, 'archived_at_ms' => null]);
+    }
+
+    public function test_only_owner_can_change_archive_state(): void
+    {
+        $owner = $this->user();
+        $editor = $this->user();
+        $viewer = $this->user();
+        $trip = $this->trip($owner);
+        $this->addMember($trip, $editor, 1);
+        $this->addMember($trip, $viewer, 2);
+
+        $this->actingAs($editor)
+            ->patchJson('/api/trips/' . $trip->id . '/archive', ['archived' => true])
+            ->assertForbidden();
+        $this->actingAs($viewer)
+            ->patchJson('/api/trips/' . $trip->id . '/archive', ['archived' => true])
+            ->assertForbidden();
+        $this->assertDatabaseHas('trips', ['id' => $trip->id, 'archived_at_ms' => null]);
+    }
+
+    public function test_trip_index_returns_archived_trips_only_for_the_archived_filter(): void
+    {
+        $owner = $this->user();
+        $active = $this->trip($owner, ['title' => 'Active', 'timestamp_end_ms' => 200]);
+        $past = $this->trip($owner, ['title' => 'Past', 'timestamp_end_ms' => 50]);
+        $olderArchived = $this->trip($owner, ['title' => 'Older archived', 'archived_at_ms' => 300]);
+        $newerArchived = $this->trip($owner, ['title' => 'Newer archived', 'archived_at_ms' => 400]);
+
+        $this->actingAs($owner)->getJson('/api/trips?status=active&now=100')
+            ->assertOk()
+            ->assertJsonPath('data.0.id', $active->id)
+            ->assertJsonCount(1, 'data');
+        $this->actingAs($owner)->getJson('/api/trips?status=past&now=100')
+            ->assertOk()
+            ->assertJsonPath('data.0.id', $past->id)
+            ->assertJsonCount(1, 'data');
+        $this->actingAs($owner)->getJson('/api/trips')
+            ->assertOk()
+            ->assertJsonMissing(['id' => $olderArchived->id])
+            ->assertJsonMissing(['id' => $newerArchived->id]);
+        $this->actingAs($owner)->getJson('/api/trips?status=archived')
+            ->assertOk()
+            ->assertJsonPath('data.0.id', $newerArchived->id)
+            ->assertJsonPath('data.1.id', $olderArchived->id)
+            ->assertJsonCount(2, 'data');
+    }
+
+    public function test_archived_trip_rejects_content_mutations_with_conflict(): void
+    {
+        $owner = $this->user();
+        $trip = $this->trip($owner, ['archived_at_ms' => 1000]);
+        $activity = Activity::create([
+            'id' => (string) Str::uuid(),
+            'trip_id' => $trip->id,
+            'title' => 'Existing activity',
+            'location' => '',
+            'description' => '',
+        ]);
+
+        $this->actingAs($owner)->putJson('/api/trips/' . $trip->id, ['title' => 'Blocked'])
+            ->assertConflict();
+        $this->actingAs($owner)->postJson('/api/trips/' . $trip->id . '/activities', [
+            'title' => 'Blocked activity', 'location' => '', 'description' => '',
+        ])->assertConflict();
+        $this->actingAs($owner)->putJson('/api/activities/' . $activity->id, ['title' => 'Blocked direct update'])
+            ->assertConflict();
+        $this->actingAs($owner)->postJson('/api/trips/' . $trip->id . '/task-lists', [
+            'title' => 'Blocked list', 'index' => 0, 'status' => 0,
+        ])->assertConflict();
+        $this->actingAs($owner)->postJson('/api/trips/' . $trip->id . '/comment-groups', [
+            'content' => 'Blocked comment', 'objectType' => 0, 'objectId' => $trip->id,
+        ])->assertConflict();
+    }
+
+    public function test_archived_trip_keeps_reads_and_management_exceptions_available(): void
+    {
+        $owner = $this->user();
+        $trip = $this->trip($owner, ['archived_at_ms' => 1000]);
+
+        $this->actingAs($owner)->getJson('/api/trips/' . $trip->id)
+            ->assertOk()
+            ->assertJsonPath('archivedAt', 1000);
+        $this->actingAs($owner)->patchJson('/api/trips/' . $trip->id . '/sharing', ['sharingLevel' => 2])
+            ->assertOk()
+            ->assertJsonPath('sharingLevel', 2);
+        $member = $this->actingAs($owner)->postJson('/api/trips/' . $trip->id . '/members', [
+            'email' => 'member@example.com', 'role' => 1,
+        ])->assertCreated()->json('user');
+        $this->actingAs($owner)->deleteJson('/api/trips/' . $trip->id . '/members/' . $member['id'])
+            ->assertOk();
+        $this->actingAs($owner)->postJson('/api/trips/' . $trip->id . '/duplicate', [
+            'title' => 'Blocked copy',
+            'startDateMs' => 300,
+            'endDateMs' => 400,
+            'includeActivities' => false,
+            'includeAccommodations' => false,
+            'includeMacroplans' => false,
+            'includeExpenses' => false,
+            'includeTasks' => false,
+            'removeActivityDates' => false,
+        ])->assertConflict();
+        $this->actingAs($owner)->deleteJson('/api/trips/' . $trip->id)->assertOk();
+    }
+}

--- a/docs/trip-archival-plan.md
+++ b/docs/trip-archival-plan.md
@@ -1,0 +1,95 @@
+# Trip archival plan
+
+## Goal
+
+Let an owner archive a completed trip without deleting its data. An archived
+trip remains viewable to everyone who could previously view it, but no trip
+data can be changed until the owner unarchives it. Archival is an explicit
+state; it is not inferred from the trip end date.
+
+## Proposed lifecycle
+
+1. Add nullable `archived_at_ms` to `trips` and expose it as
+   `archivedAt` in the trip-list and full-trip API payloads. `null` means
+   active; a millisecond timestamp records when the trip was archived.
+2. Add an owner-only, idempotent archive mutation. It sets `archived_at_ms`
+   and updates `updated_at_ms`. The matching unarchive mutation clears it.
+3. Treat archival as a server-enforced trip-wide write lock. The read APIs,
+   direct trip URL, exports, print, and duplicate remain available. Every
+   mutation of the trip graph returns a clear `409 Conflict` when archived.
+4. Put archiving and unarchiving in the owner section of the trip menu. Both
+   actions use a confirmation dialog; the archive dialog explains that the
+   trip will become read-only. While archived, hide or disable all edit and
+   destructive controls and show a persistent “Archived — read-only” banner.
+5. Exclude archived trips from the normal active/past list requests. Add an
+   explicit archive entry point that loads a paginated archived list, ordered
+   by `archived_at_ms` descending. Opening an archived trip works exactly as
+   opening any other trip.
+6. On unarchive, clear the archive timestamp, refresh the open trip and trip
+   lists, remove the read-only banner, and return the trip to its existing
+   active/past grouping (which is still based on the end date).
+
+## Backend work
+
+- Create a migration for `trips.archived_at_ms`, with an index suitable for
+  member-scoped archive retrieval. Add the field to `Trip` casts and response
+  serializers.
+- Extend `GET /api/trips` with an archive filter. Preserve today's `active`
+  and `past` meanings for non-archived trips; use `status=archived` for the
+  archive view and cursor pagination.
+- Add a dedicated owner-only archive state endpoint, for example
+  `PATCH /api/trips/{trip}/archive` with `{ "archived": true|false }`.
+  Validate state transitions server-side and make repeat requests safe.
+- Centralize the write-lock check in `TripAccessService` (or dedicated
+  middleware) and apply it to every mutation. This must cover trip updates,
+  sharing, members, all child entities, task lists/tasks, comments, batch and
+  drag operations, and the current direct-ID write routes. Do not rely on
+  frontend disabled controls.
+- Decide and document the treatment of mutations that change access rather
+  than content (sharing, members, and deletion); see decision points below.
+
+## Frontend work
+
+- Extend trip types, API mappers, and store state with `archivedAt`.
+- Split the existing trip fetches into normal active/past and an on-demand
+  archived query. Keep archive pagination independent from past-trip “load
+  more”.
+- Add an Archived Trips entry from the trips screen, empty/loading/error
+  states, and a way back to the normal list.
+- Add archive/unarchive controls and confirmation dialogs for owners only.
+  Ensure a loaded archived trip makes all edit controls consistently
+  unavailable, including keyboard/secondary entry points.
+- Show the archived status in cards and the trip header so a direct link does
+  not look editable before the menu is opened.
+
+## Verification
+
+- Migration and API tests: an owner can archive/unarchive; editors/viewers
+  cannot; repeated requests are safe; `archivedAt` is serialized correctly.
+- List tests: archived trips are absent from active/past, returned only by the
+  archived query, pagination remains stable, and unarchive restores normal
+  grouping.
+- Authorization matrix tests: every content, task, comment, member, sharing,
+  direct-ID, and bulk mutation is rejected for archived trips, while permitted
+  reads, print/export, and duplication continue to work.
+- UI tests: owner controls, confirmation, read-only banner, archive retrieval,
+  and unarchive refresh behavior.
+
+## Decisions needed
+
+1. **Who may archive/unarchive?** Proposed: owners only. Editors and viewers
+   can still view, print, export, and duplicate according to existing access.
+2. **Visibility after archival:** should public/shared visibility be preserved,
+   or should archive automatically make the trip private/unlisted?
+3. **What exactly is locked?** Proposed: all mutations, including sharing,
+   membership, and deletion; only unarchive is allowed. An alternative is to
+   let owners still change sharing/members or delete while the content remains
+   locked.
+4. **Where is it retrieved?** Proposed: remove it from the default list and
+   provide a dedicated, on-demand “Archived trips” view. An alternative is a
+   collapsed Archived section at the end of the normal trips page.
+5. **When is it eligible?** Proposed: any owner can archive at any time. An
+   alternative is only after the trip end date has passed.
+6. **Are any writes exempt?** Proposed: no. In particular, comments and task
+   completion are read-only too. An alternative is to permit post-trip expense
+   reconciliation and/or comments.

--- a/docs/trip-archival-plan.md
+++ b/docs/trip-archival-plan.md
@@ -15,9 +15,9 @@ it. Archival is an explicit state; it is not inferred from the trip end date.
 2. Add an owner-only, idempotent archive mutation. It sets `archived_at_ms`
    and updates `updated_at_ms`. The matching unarchive mutation clears it.
 3. Treat archival as a server-enforced content write lock. The read APIs,
-   direct trip URL, exports, print, and duplicate remain available. Content
-   mutations return a clear `409 Conflict` when archived, but owners may still
-   change sharing and membership or delete the trip.
+   direct trip URL, exports, and print remain available. Content mutations,
+   including duplication, return a clear `409 Conflict` when archived, but
+   owners may still change sharing and membership or delete the trip.
 4. Put archiving and unarchiving in the owner section of the trip menu. Both
    actions use a confirmation dialog; the archive dialog explains that the
    trip content will become read-only. While archived, hide or disable content
@@ -70,24 +70,24 @@ it. Archival is an explicit state; it is not inferred from the trip end date.
 - List tests: archived trips are absent from active/past, returned only by the
   archived query, pagination remains stable, and unarchive restores normal
   grouping.
-- Authorization matrix tests: all content, task, comment, direct-ID, and bulk
-  mutations are rejected for archived trips; owner sharing, member management,
-  and deletion remain permitted; reads, print/export, and duplication continue
-  to work.
+- Authorization matrix tests: all content, task, comment, direct-ID, bulk,
+  and duplicate mutations are rejected for archived trips; owner sharing,
+  member management, and deletion remain permitted; reads and print/export
+  continue to work.
 - UI tests: owner controls, confirmation, read-only banner, archive retrieval,
   and unarchive refresh behavior.
 
 ## Confirmed behavior
 
 - Only owners may archive or unarchive. Editors and viewers retain their
-  existing read, print, export, and duplicate permissions.
+  existing read, print, and export permissions.
 - Archival preserves the trip's existing private/shared/public visibility.
 - Archival may occur at any time.
 - Archived trips are retrieved from a separate Archived Trips page linked from
   the normal trips page. This page has one chronological list rather than
   upcoming/ongoing/past groups.
 - Archival locks every content mutation, including trip metadata, comments,
-  tasks, and expenses. Owner sharing changes, member additions/removals, and
-  trip deletion remain allowed.
+  tasks, expenses, and duplication. Owner sharing changes, member
+  additions/removals, and trip deletion remain allowed.
 - A future policy may require archiving before deletion; it is explicitly out
   of scope for this change.

--- a/docs/trip-archival-plan.md
+++ b/docs/trip-archival-plan.md
@@ -2,10 +2,10 @@
 
 ## Goal
 
-Let an owner archive a completed trip without deleting its data. An archived
-trip remains viewable to everyone who could previously view it, but no trip
-data can be changed until the owner unarchives it. Archival is an explicit
-state; it is not inferred from the trip end date.
+Let an owner archive a trip without deleting its data. An archived trip
+preserves its existing visibility and remains viewable to everyone who could
+previously view it. Its content becomes read-only until the owner unarchives
+it. Archival is an explicit state; it is not inferred from the trip end date.
 
 ## Proposed lifecycle
 
@@ -14,13 +14,15 @@ state; it is not inferred from the trip end date.
    active; a millisecond timestamp records when the trip was archived.
 2. Add an owner-only, idempotent archive mutation. It sets `archived_at_ms`
    and updates `updated_at_ms`. The matching unarchive mutation clears it.
-3. Treat archival as a server-enforced trip-wide write lock. The read APIs,
-   direct trip URL, exports, print, and duplicate remain available. Every
-   mutation of the trip graph returns a clear `409 Conflict` when archived.
+3. Treat archival as a server-enforced content write lock. The read APIs,
+   direct trip URL, exports, print, and duplicate remain available. Content
+   mutations return a clear `409 Conflict` when archived, but owners may still
+   change sharing and membership or delete the trip.
 4. Put archiving and unarchiving in the owner section of the trip menu. Both
    actions use a confirmation dialog; the archive dialog explains that the
-   trip will become read-only. While archived, hide or disable all edit and
-   destructive controls and show a persistent “Archived — read-only” banner.
+   trip content will become read-only. While archived, hide or disable content
+   editing controls and show a persistent “Archived — content is read-only”
+   banner. Keep owner sharing and delete actions available.
 5. Exclude archived trips from the normal active/past list requests. Add an
    explicit archive entry point that loads a paginated archived list, ordered
    by `archived_at_ms` descending. Opening an archived trip works exactly as
@@ -40,13 +42,11 @@ state; it is not inferred from the trip end date.
 - Add a dedicated owner-only archive state endpoint, for example
   `PATCH /api/trips/{trip}/archive` with `{ "archived": true|false }`.
   Validate state transitions server-side and make repeat requests safe.
-- Centralize the write-lock check in `TripAccessService` (or dedicated
-  middleware) and apply it to every mutation. This must cover trip updates,
-  sharing, members, all child entities, task lists/tasks, comments, batch and
-  drag operations, and the current direct-ID write routes. Do not rely on
-  frontend disabled controls.
-- Decide and document the treatment of mutations that change access rather
-  than content (sharing, members, and deletion); see decision points below.
+- Centralize the content write-lock check in `TripAccessService` (or dedicated
+  middleware). Apply it to trip metadata updates and all child-entity, task,
+  comment, batch, drag, and direct-ID content routes. Do not apply it to
+  sharing, member management, deletion, or the archive-state endpoint, and do
+  not rely on frontend disabled controls.
 
 ## Frontend work
 
@@ -57,8 +57,9 @@ state; it is not inferred from the trip end date.
 - Add an Archived Trips entry from the trips screen, empty/loading/error
   states, and a way back to the normal list.
 - Add archive/unarchive controls and confirmation dialogs for owners only.
-  Ensure a loaded archived trip makes all edit controls consistently
-  unavailable, including keyboard/secondary entry points.
+  Ensure a loaded archived trip makes every content-edit control consistently
+  unavailable, including keyboard/secondary entry points, while retaining
+  owner sharing and deletion controls.
 - Show the archived status in cards and the trip header so a direct link does
   not look editable before the menu is opened.
 
@@ -69,27 +70,24 @@ state; it is not inferred from the trip end date.
 - List tests: archived trips are absent from active/past, returned only by the
   archived query, pagination remains stable, and unarchive restores normal
   grouping.
-- Authorization matrix tests: every content, task, comment, member, sharing,
-  direct-ID, and bulk mutation is rejected for archived trips, while permitted
-  reads, print/export, and duplication continue to work.
+- Authorization matrix tests: all content, task, comment, direct-ID, and bulk
+  mutations are rejected for archived trips; owner sharing, member management,
+  and deletion remain permitted; reads, print/export, and duplication continue
+  to work.
 - UI tests: owner controls, confirmation, read-only banner, archive retrieval,
   and unarchive refresh behavior.
 
-## Decisions needed
+## Confirmed behavior
 
-1. **Who may archive/unarchive?** Proposed: owners only. Editors and viewers
-   can still view, print, export, and duplicate according to existing access.
-2. **Visibility after archival:** should public/shared visibility be preserved,
-   or should archive automatically make the trip private/unlisted?
-3. **What exactly is locked?** Proposed: all mutations, including sharing,
-   membership, and deletion; only unarchive is allowed. An alternative is to
-   let owners still change sharing/members or delete while the content remains
-   locked.
-4. **Where is it retrieved?** Proposed: remove it from the default list and
-   provide a dedicated, on-demand “Archived trips” view. An alternative is a
-   collapsed Archived section at the end of the normal trips page.
-5. **When is it eligible?** Proposed: any owner can archive at any time. An
-   alternative is only after the trip end date has passed.
-6. **Are any writes exempt?** Proposed: no. In particular, comments and task
-   completion are read-only too. An alternative is to permit post-trip expense
-   reconciliation and/or comments.
+- Only owners may archive or unarchive. Editors and viewers retain their
+  existing read, print, export, and duplicate permissions.
+- Archival preserves the trip's existing private/shared/public visibility.
+- Archival may occur at any time.
+- Archived trips are retrieved from a separate Archived Trips page linked from
+  the normal trips page. This page has one chronological list rather than
+  upcoming/ongoing/past groups.
+- Archival locks every content mutation, including trip metadata, comments,
+  tasks, and expenses. Owner sharing changes, member additions/removals, and
+  trip deletion remain allowed.
+- A future policy may require archiving before deletion; it is explicitly out
+  of scope for this change.

--- a/src/Accommodation/AccommodationDialog/AccommodationDialogContentView.tsx
+++ b/src/Accommodation/AccommodationDialog/AccommodationDialogContentView.tsx
@@ -52,10 +52,11 @@ export function AccommodationDialogContentView({
   const currentUser = useDeepBoundStore((state) => state.currentUser);
   const userCanEditOrDelete = useMemo(() => {
     return (
-      trip?.currentUserRole === TripUserRole.Owner ||
-      trip?.currentUserRole === TripUserRole.Editor
+      trip?.archivedAt == null &&
+      (trip?.currentUserRole === TripUserRole.Owner ||
+        trip?.currentUserRole === TripUserRole.Editor)
     );
-  }, [trip?.currentUserRole]);
+  }, [trip]);
 
   const goToEditMode = useCallback(() => {
     setMode(AccommodationDialogMode.Edit);

--- a/src/Accommodation/AccommodationDialog/AccommodationDialogContentView.tsx
+++ b/src/Accommodation/AccommodationDialog/AccommodationDialogContentView.tsx
@@ -7,16 +7,16 @@ import {
   Text,
 } from '@radix-ui/themes';
 
-import { useCallback, useMemo } from 'react';
+import { useCallback } from 'react';
 import { CommentGroupWithForm } from '../../Comment/CommentGroupWithForm';
 import { COMMENT_GROUP_OBJECT_TYPE } from '../../Comment/db';
 import { toFormat } from '../../common/dateTime/temporalFormatter';
 import { useParseTextIntoNodes } from '../../common/text/parseTextIntoNodes';
 import type { DialogContentProps } from '../../Dialog/DialogRoute';
 import { useDeepBoundStore } from '../../data/store';
+import { canModifyTripContent } from '../../Trip/permissions';
 import { useTrip } from '../../Trip/store/hooks';
 import type { TripSliceAccommodation } from '../../Trip/store/types';
-import { TripUserRole } from '../../User/TripUserRole';
 import s from './AccommodationDialog.module.css';
 import { AccommodationMap } from './AccommodationDialogMap';
 import { AccommodationDialogMode } from './AccommodationDialogMode';
@@ -50,13 +50,7 @@ export function AccommodationDialogContentView({
       : undefined;
   const notes = useParseTextIntoNodes(accommodation?.notes);
   const currentUser = useDeepBoundStore((state) => state.currentUser);
-  const userCanEditOrDelete = useMemo(() => {
-    return (
-      trip?.archivedAt == null &&
-      (trip?.currentUserRole === TripUserRole.Owner ||
-        trip?.currentUserRole === TripUserRole.Editor)
-    );
-  }, [trip]);
+  const userCanEditOrDelete = canModifyTripContent(trip);
 
   const goToEditMode = useCallback(() => {
     setMode(AccommodationDialogMode.Edit);

--- a/src/Activity/ActivityDialog/ActivityDialogContentView.tsx
+++ b/src/Activity/ActivityDialog/ActivityDialogContentView.tsx
@@ -14,9 +14,9 @@ import { toFormat } from '../../common/dateTime/temporalFormatter';
 import { useParseTextIntoNodes } from '../../common/text/parseTextIntoNodes';
 import type { DialogContentProps } from '../../Dialog/DialogRoute';
 import { useDeepBoundStore } from '../../data/store';
+import { canModifyTripContent } from '../../Trip/permissions';
 import { useTrip } from '../../Trip/store/hooks';
 import type { TripSliceActivity } from '../../Trip/store/types';
-import { TripUserRole } from '../../User/TripUserRole';
 import { getActivityDisplayTitle } from '../activityTitle';
 import {
   ActivityType,
@@ -37,13 +37,7 @@ export function ActivityDialogContentView({
   loading,
 }: DialogContentProps<TripSliceActivity>) {
   const { trip } = useTrip(activity?.tripId);
-  const userCanEditOrDelete = useMemo(() => {
-    return (
-      trip?.archivedAt == null &&
-      (trip?.currentUserRole === TripUserRole.Owner ||
-        trip?.currentUserRole === TripUserRole.Editor)
-    );
-  }, [trip]);
+  const userCanEditOrDelete = canModifyTripContent(trip);
 
   const activityStartDateTime =
     activity && trip && activity.timestampStart != null

--- a/src/Activity/ActivityDialog/ActivityDialogContentView.tsx
+++ b/src/Activity/ActivityDialog/ActivityDialogContentView.tsx
@@ -39,10 +39,11 @@ export function ActivityDialogContentView({
   const { trip } = useTrip(activity?.tripId);
   const userCanEditOrDelete = useMemo(() => {
     return (
-      trip?.currentUserRole === TripUserRole.Owner ||
-      trip?.currentUserRole === TripUserRole.Editor
+      trip?.archivedAt == null &&
+      (trip?.currentUserRole === TripUserRole.Owner ||
+        trip?.currentUserRole === TripUserRole.Editor)
     );
-  }, [trip?.currentUserRole]);
+  }, [trip]);
 
   const activityStartDateTime =
     activity && trip && activity.timestampStart != null

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -25,6 +25,7 @@ import {
   RouteTrip,
   RouteTripNew,
   RouteTrips,
+  RouteTripsArchived,
   RouteTripsPublic,
 } from './Routes/routes';
 import { ImperativeToastRoot } from './Toast/ImperativeToast';
@@ -39,6 +40,9 @@ const PageTerms = withLoading()(React.lazy(() => import('./Docs/Terms')));
 const PagePrivacy = withLoading()(React.lazy(() => import('./Docs/Privacy')));
 const PageLogin = withLoading()(React.lazy(() => import('./Auth/Auth')));
 const PageTrips = withLoading()(React.lazy(() => import('./Trips/PageTrips')));
+const PageTripsArchived = withLoading()(
+  React.lazy(() => import('./Trips/PageTripsArchived')),
+);
 const PageTripsPublic = withLoading()(
   React.lazy(() => import('./TripsPublic/PageTripsPublic')),
 );
@@ -155,6 +159,10 @@ function App() {
             ) : null}
             <Route path={RouteLogin.routePath} component={PageLogin} />
             <Route path={RouteTrips.routePath} component={PageTrips} />
+            <Route
+              path={RouteTripsArchived.routePath}
+              component={PageTripsArchived}
+            />
             <Route
               path={RouteTripsPublic.routePath}
               component={PageTripsPublic}

--- a/src/Comment/Comment.tsx
+++ b/src/Comment/Comment.tsx
@@ -24,7 +24,7 @@ import {
   RouteTripTimetableViewActivity,
   RouteTripTimetableViewMacroplan,
 } from '../Routes/routes';
-import { useTripCommentGroup } from '../Trip/store/hooks';
+import { useTrip, useTripCommentGroup } from '../Trip/store/hooks';
 import type { TripSliceCommentWithUser } from '../Trip/store/types';
 import s from './Comment.module.css';
 import { CommentForm } from './CommentForm';
@@ -44,6 +44,7 @@ function CommentInner({
 }) {
   const currentUser = useDeepBoundStore((state) => state.currentUser);
   const commentGroup = useTripCommentGroup(comment.commentGroupId);
+  const { trip } = useTrip(commentGroup?.tripId);
 
   const { user } = comment;
   const isCommentOwnedByCurrentUser = useMemo(() => {
@@ -216,7 +217,9 @@ function CommentInner({
                 {nodes}
               </Text>
             </Card>
-            {showControls && isCommentOwnedByCurrentUser ? (
+            {showControls &&
+            isCommentOwnedByCurrentUser &&
+            trip?.archivedAt == null ? (
               <Flex align="baseline" gap="2">
                 <Button
                   size="1"

--- a/src/Comment/CommentGroupWithForm.tsx
+++ b/src/Comment/CommentGroupWithForm.tsx
@@ -34,10 +34,11 @@ export function CommentGroupWithForm({
   const { trip } = useTrip(tripId);
   const userCanComment = useMemo(() => {
     return (
-      trip?.currentUserRole === TripUserRole.Owner ||
-      trip?.currentUserRole === TripUserRole.Editor
+      trip?.archivedAt == null &&
+      (trip?.currentUserRole === TripUserRole.Owner ||
+        trip?.currentUserRole === TripUserRole.Editor)
     );
-  }, [trip?.currentUserRole]);
+  }, [trip]);
   const sectionVisibility = trip ? getSectionVisibility(trip) : null;
 
   return (

--- a/src/Comment/CommentGroupWithForm.tsx
+++ b/src/Comment/CommentGroupWithForm.tsx
@@ -1,10 +1,9 @@
 import { LockClosedIcon } from '@radix-ui/react-icons';
 import { Flex, Spinner, Text } from '@radix-ui/themes';
-import { useMemo } from 'react';
 import type { DbUser } from '../data/types';
+import { canModifyTripContent } from '../Trip/permissions';
 import { getSectionVisibility } from '../Trip/sectionVisibility';
 import { useTrip, useTripCommentGroup } from '../Trip/store/hooks';
-import { TripUserRole } from '../User/TripUserRole';
 import { CommentForm } from './CommentForm';
 import { CommentGroup } from './CommentGroup';
 import { CommentMode } from './CommentMode';
@@ -32,13 +31,7 @@ export function CommentGroupWithForm({
 }) {
   const commentGroup = useTripCommentGroup(commentGroupId);
   const { trip } = useTrip(tripId);
-  const userCanComment = useMemo(() => {
-    return (
-      trip?.archivedAt == null &&
-      (trip?.currentUserRole === TripUserRole.Owner ||
-        trip?.currentUserRole === TripUserRole.Editor)
-    );
-  }, [trip]);
+  const userCanComment = canModifyTripContent(trip);
   const sectionVisibility = trip ? getSectionVisibility(trip) : null;
 
   return (

--- a/src/Expense/ExpenseCard.tsx
+++ b/src/Expense/ExpenseCard.tsx
@@ -120,10 +120,11 @@ function ExpenseCardView({
 
   const userCanEditOrDelete = useMemo(() => {
     return (
-      trip?.currentUserRole === TripUserRole.Owner ||
-      trip?.currentUserRole === TripUserRole.Editor
+      trip?.archivedAt == null &&
+      (trip?.currentUserRole === TripUserRole.Owner ||
+        trip?.currentUserRole === TripUserRole.Editor)
     );
-  }, [trip?.currentUserRole]);
+  }, [trip]);
   return (
     <Collapsible open={isExpanded} onOpenChange={setIsExpanded} asChild>
       <Inset className={s.cardContent}>

--- a/src/Expense/ExpenseCard.tsx
+++ b/src/Expense/ExpenseCard.tsx
@@ -21,14 +21,14 @@ import {
   Tooltip,
 } from '@radix-ui/themes';
 
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useState } from 'react';
 import { CommentGroupWithForm } from '../Comment/CommentGroupWithForm';
 import { COMMENT_GROUP_OBJECT_TYPE } from '../Comment/db';
 import { dangerToken } from '../common/ui';
 import { useBoundStore, useDeepBoundStore } from '../data/store';
+import { canModifyTripContent } from '../Trip/permissions';
 import { useTrip } from '../Trip/store/hooks';
 import type { TripSliceExpense } from '../Trip/store/types';
-import { TripUserRole } from '../User/TripUserRole';
 import { formatCurrencyAmount } from './currency';
 import { dbDeleteExpense } from './db';
 import s from './ExpenseCard.module.css';
@@ -118,13 +118,7 @@ function ExpenseCardView({
       });
   }, [expense.id, expense.title, publishToast]);
 
-  const userCanEditOrDelete = useMemo(() => {
-    return (
-      trip?.archivedAt == null &&
-      (trip?.currentUserRole === TripUserRole.Owner ||
-        trip?.currentUserRole === TripUserRole.Editor)
-    );
-  }, [trip]);
+  const userCanEditOrDelete = canModifyTripContent(trip);
   return (
     <Collapsible open={isExpanded} onOpenChange={setIsExpanded} asChild>
       <Inset className={s.cardContent}>

--- a/src/Macroplan/MacroplanDialog/MacroplanDialogContentView.tsx
+++ b/src/Macroplan/MacroplanDialog/MacroplanDialogContentView.tsx
@@ -28,10 +28,11 @@ export function MacroplanDialogContentView({
   const { trip } = useTrip(macroplan?.tripId);
   const userCanEditOrDelete = useMemo(() => {
     return (
-      trip?.currentUserRole === TripUserRole.Owner ||
-      trip?.currentUserRole === TripUserRole.Editor
+      trip?.archivedAt == null &&
+      (trip?.currentUserRole === TripUserRole.Owner ||
+        trip?.currentUserRole === TripUserRole.Editor)
     );
-  }, [trip?.currentUserRole]);
+  }, [trip]);
   const macroplanDateRangeString =
     trip && macroplan
       ? formatMacroplanDateRange({

--- a/src/Macroplan/MacroplanDialog/MacroplanDialogContentView.tsx
+++ b/src/Macroplan/MacroplanDialog/MacroplanDialogContentView.tsx
@@ -6,15 +6,15 @@ import {
   Skeleton,
   Text,
 } from '@radix-ui/themes';
-import { useCallback, useMemo } from 'react';
+import { useCallback } from 'react';
 import { CommentGroupWithForm } from '../../Comment/CommentGroupWithForm';
 import { COMMENT_GROUP_OBJECT_TYPE } from '../../Comment/db';
 import { useParseTextIntoNodes } from '../../common/text/parseTextIntoNodes';
 import type { DialogContentProps } from '../../Dialog/DialogRoute';
 import { useDeepBoundStore } from '../../data/store';
+import { canModifyTripContent } from '../../Trip/permissions';
 import { useTrip } from '../../Trip/store/hooks';
 import type { TripSliceMacroplan } from '../../Trip/store/types';
-import { TripUserRole } from '../../User/TripUserRole';
 import { formatMacroplanDateRange } from '../time';
 import s from './MacroplanDialog.module.css';
 import { MacroplanDialogMode } from './MacroplanDialogMode';
@@ -26,13 +26,7 @@ export function MacroplanDialogContentView({
   DialogTitleSection,
 }: DialogContentProps<TripSliceMacroplan>) {
   const { trip } = useTrip(macroplan?.tripId);
-  const userCanEditOrDelete = useMemo(() => {
-    return (
-      trip?.archivedAt == null &&
-      (trip?.currentUserRole === TripUserRole.Owner ||
-        trip?.currentUserRole === TripUserRole.Editor)
-    );
-  }, [trip]);
+  const userCanEditOrDelete = canModifyTripContent(trip);
   const macroplanDateRangeString =
     trip && macroplan
       ? formatMacroplanDateRange({

--- a/src/Routes/routes.ts
+++ b/src/Routes/routes.ts
@@ -2,6 +2,7 @@ import { createRouteParam, identity, replaceId } from './definition';
 
 export const RouteLogin = createRouteParam('/login', identity);
 export const RouteTrips = createRouteParam('/trip', identity);
+export const RouteTripsArchived = createRouteParam('/trip/archived', identity);
 export const RouteTripsPublic = createRouteParam('/trip/public', identity);
 export const RouteTripNew = createRouteParam('/trip/new', identity);
 export const RouteTrip = createRouteParam('/trip/:id', replaceId);

--- a/src/Trip/PageTrip.tsx
+++ b/src/Trip/PageTrip.tsx
@@ -1,4 +1,4 @@
-import { Container, Spinner, Text } from '@radix-ui/themes';
+import { Callout, Container, Spinner, Text } from '@radix-ui/themes';
 import React, { useEffect } from 'react';
 import {
   Link,
@@ -128,6 +128,16 @@ function PageTripInner({
     <>
       <DocTitle title={trip?.title ?? 'Trip'} />
       <TripNavbar />
+      {trip?.archivedAt != null ? (
+        <Container>
+          <Callout.Root my="2" color="gray" role="note">
+            <Callout.Icon>
+              <span aria-hidden>🔒</span>
+            </Callout.Icon>
+            <Callout.Text>Archived — content is read-only.</Callout.Text>
+          </Callout.Root>
+        </Container>
+      ) : null}
       {!trip ? (
         loading ? (
           <Spinner size="2" />

--- a/src/Trip/TripDialog/TripArchiveDialog.tsx
+++ b/src/Trip/TripDialog/TripArchiveDialog.tsx
@@ -1,0 +1,76 @@
+import { AlertDialog, Button, Flex, Text } from '@radix-ui/themes';
+import { useCallback, useState } from 'react';
+import { CommonDialogMaxWidth } from '../../Dialog/ui';
+import { useBoundStore } from '../../data/store';
+import { dbSetTripArchived } from '../db';
+import type { TripSliceTrip } from '../store/types';
+
+export function TripArchiveDialog({ trip }: { trip: TripSliceTrip }) {
+  const archived = trip.archivedAt != null;
+  const popDialog = useBoundStore((state) => state.popDialog);
+  const publishToast = useBoundStore((state) => state.publishToast);
+  const [submitting, setSubmitting] = useState(false);
+  const submit = useCallback(() => {
+    setSubmitting(true);
+    void dbSetTripArchived(trip.id, !archived)
+      .then(() => {
+        publishToast({
+          root: {},
+          title: {
+            children: archived
+              ? `Trip "${trip.title}" unarchived`
+              : `Trip "${trip.title}" archived`,
+          },
+          close: {},
+        });
+        popDialog();
+      })
+      .catch((error: unknown) => {
+        console.error(
+          `Error updating archive state for "${trip.title}"`,
+          error,
+        );
+        publishToast({
+          root: {},
+          title: { children: 'Unable to update trip archive state' },
+          close: {},
+        });
+        setSubmitting(false);
+      });
+  }, [archived, popDialog, publishToast, trip.id, trip.title]);
+
+  return (
+    <AlertDialog.Root defaultOpen>
+      <AlertDialog.Content maxWidth={CommonDialogMaxWidth}>
+        <AlertDialog.Title>
+          {archived ? 'Unarchive trip' : 'Archive trip'}
+        </AlertDialog.Title>
+        <AlertDialog.Description size="2">
+          {archived ? (
+            <Text as="p">
+              Unarchive "{trip.title}"? Its content will become editable again
+              for owners and editors.
+            </Text>
+          ) : (
+            <Text as="p">
+              Archive "{trip.title}"? Its content will become read-only.
+              Sharing, members, and deletion will remain available to owners.
+            </Text>
+          )}
+        </AlertDialog.Description>
+        <Flex gap="3" mt="4" justify="end">
+          <AlertDialog.Cancel onClick={popDialog}>
+            <Button variant="soft" color="gray" disabled={submitting}>
+              Cancel
+            </Button>
+          </AlertDialog.Cancel>
+          <AlertDialog.Action onClick={submit}>
+            <Button loading={submitting}>
+              {archived ? 'Unarchive trip' : 'Archive trip'}
+            </Button>
+          </AlertDialog.Action>
+        </Flex>
+      </AlertDialog.Content>
+    </AlertDialog.Root>
+  );
+}

--- a/src/Trip/TripExpenseViewCards.tsx
+++ b/src/Trip/TripExpenseViewCards.tsx
@@ -9,14 +9,14 @@ import {
   Text,
 } from '@radix-ui/themes';
 import clsx from 'clsx';
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useState } from 'react';
 import { downloadCsv, expensesToCsv } from '../Expense/csvExport';
 import { ExpenseCard } from '../Expense/ExpenseCard';
 import { ExpenseHeaderCard } from '../Expense/ExpenseHeaderCard';
 import { ExpenseInlineCardForm } from '../Expense/ExpenseInlineCardForm';
 import { ExpenseMode } from '../Expense/ExpenseMode';
 import { DocTitle } from '../Nav/DocTitle';
-import { TripUserRole } from '../User/TripUserRole';
+import { canModifyTripContent } from './permissions';
 import { getSectionVisibility } from './sectionVisibility';
 import { useCurrentTrip, useTripExpenses } from './store/hooks';
 import s from './TripExpenseViewCards.module.css';
@@ -27,13 +27,7 @@ export function TripExpenseViewCards() {
   const expenseIds = trip?.expenseIds ?? [];
   const expenses = useTripExpenses(expenseIds);
   const [expenseMode, setExpenseMode] = useState(ExpenseMode.View);
-  const userCanModifyExpense = useMemo(() => {
-    return (
-      trip?.archivedAt == null &&
-      (trip?.currentUserRole === TripUserRole.Owner ||
-        trip?.currentUserRole === TripUserRole.Editor)
-    );
-  }, [trip]);
+  const userCanModifyExpense = canModifyTripContent(trip);
   const handleAddExpenseClick = useCallback(() => {
     setExpenseMode(ExpenseMode.Add);
   }, []);

--- a/src/Trip/TripExpenseViewCards.tsx
+++ b/src/Trip/TripExpenseViewCards.tsx
@@ -29,10 +29,11 @@ export function TripExpenseViewCards() {
   const [expenseMode, setExpenseMode] = useState(ExpenseMode.View);
   const userCanModifyExpense = useMemo(() => {
     return (
-      trip?.currentUserRole === TripUserRole.Owner ||
-      trip?.currentUserRole === TripUserRole.Editor
+      trip?.archivedAt == null &&
+      (trip?.currentUserRole === TripUserRole.Owner ||
+        trip?.currentUserRole === TripUserRole.Editor)
     );
-  }, [trip?.currentUserRole]);
+  }, [trip]);
   const handleAddExpenseClick = useCallback(() => {
     setExpenseMode(ExpenseMode.Add);
   }, []);

--- a/src/Trip/TripHome/TripHeading.tsx
+++ b/src/Trip/TripHome/TripHeading.tsx
@@ -32,10 +32,11 @@ export function TripHeading() {
 
   const userCanModifyTrip = useMemo(() => {
     return (
-      trip?.currentUserRole === TripUserRole.Owner ||
-      trip?.currentUserRole === TripUserRole.Editor
+      trip?.archivedAt == null &&
+      (trip?.currentUserRole === TripUserRole.Owner ||
+        trip?.currentUserRole === TripUserRole.Editor)
     );
-  }, [trip?.currentUserRole]);
+  }, [trip]);
 
   return (
     <Flex align="start" gap="1" wrap="wrap">

--- a/src/Trip/TripHome/TripHeading.tsx
+++ b/src/Trip/TripHome/TripHeading.tsx
@@ -1,9 +1,9 @@
 import { Pencil2Icon } from '@radix-ui/react-icons';
 import { Badge, Button, Flex, Heading } from '@radix-ui/themes';
 
-import { useCallback, useMemo } from 'react';
+import { useCallback } from 'react';
 import { useBoundStore } from '../../data/store';
-import { TripUserRole } from '../../User/TripUserRole';
+import { canModifyTripContent } from '../permissions';
 import { useCurrentTrip } from '../store/hooks';
 import { TripEditDialog } from '../TripDialog/TripEditDialog';
 import { TripStatusBadge } from '../TripStatusBadge';
@@ -30,13 +30,7 @@ export function TripHeading() {
     }
   }, [trip, pushDialog]);
 
-  const userCanModifyTrip = useMemo(() => {
-    return (
-      trip?.archivedAt == null &&
-      (trip?.currentUserRole === TripUserRole.Owner ||
-        trip?.currentUserRole === TripUserRole.Editor)
-    );
-  }, [trip]);
+  const userCanModifyTrip = canModifyTripContent(trip);
 
   return (
     <Flex align="start" gap="1" wrap="wrap">

--- a/src/Trip/TripHome/TripHomeActivities.tsx
+++ b/src/Trip/TripHome/TripHomeActivities.tsx
@@ -15,10 +15,11 @@ export function TripHomeActivities() {
   const activities = useTripActivities(trip?.activityIds ?? []);
   const userCanModifyTrip = useMemo(() => {
     return (
-      trip?.currentUserRole === TripUserRole.Owner ||
-      trip?.currentUserRole === TripUserRole.Editor
+      trip?.archivedAt == null &&
+      (trip?.currentUserRole === TripUserRole.Owner ||
+        trip?.currentUserRole === TripUserRole.Editor)
     );
-  }, [trip?.currentUserRole]);
+  }, [trip]);
 
   // Determine if trip is {stating soon, or current}
   const isTripStartingOrCurrent = useMemo(() => {

--- a/src/Trip/TripHome/TripHomeActivities.tsx
+++ b/src/Trip/TripHome/TripHomeActivities.tsx
@@ -4,7 +4,7 @@ import { useMemo } from 'react';
 import { Link } from 'wouter';
 import { Activity } from '../../Activity/Activity';
 import { RouteTripListView } from '../../Routes/routes';
-import { TripUserRole } from '../../User/TripUserRole';
+import { canModifyTripContent } from '../permissions';
 import { useCurrentTrip, useTripActivities } from '../store/hooks';
 import type { TripSliceActivityWithTime } from '../store/types';
 import { TripViewMode } from '../TripViewMode';
@@ -13,13 +13,7 @@ export function TripHomeActivities() {
   const { trip } = useCurrentTrip();
   // Get activities and expenses for new features
   const activities = useTripActivities(trip?.activityIds ?? []);
-  const userCanModifyTrip = useMemo(() => {
-    return (
-      trip?.archivedAt == null &&
-      (trip?.currentUserRole === TripUserRole.Owner ||
-        trip?.currentUserRole === TripUserRole.Editor)
-    );
-  }, [trip]);
+  const userCanModifyTrip = canModifyTripContent(trip);
 
   // Determine if trip is {stating soon, or current}
   const isTripStartingOrCurrent = useMemo(() => {

--- a/src/Trip/TripHome/TripHomeOnboarding.tsx
+++ b/src/Trip/TripHome/TripHomeOnboarding.tsx
@@ -3,7 +3,7 @@ import { Button, Flex } from '@radix-ui/themes';
 import { useCallback, useMemo } from 'react';
 import { useLocation } from 'wouter';
 import { RouteTripTimetableView } from '../../Routes/routes';
-import { TripUserRole } from '../../User/TripUserRole';
+import { canModifyTripContent } from '../permissions';
 import {
   useCurrentTrip,
   useTripAccommodations,
@@ -28,13 +28,7 @@ export function TripHomeOnboarding() {
     return Temporal.ZonedDateTime.compare(now, tripStart) >= 0;
   }, [trip]);
 
-  const userCanModifyTrip = useMemo(() => {
-    return (
-      trip?.archivedAt == null &&
-      (trip?.currentUserRole === TripUserRole.Owner ||
-        trip?.currentUserRole === TripUserRole.Editor)
-    );
-  }, [trip]);
+  const userCanModifyTrip = canModifyTripContent(trip);
 
   const [, setLocation] = useLocation();
   const openActivityNewDialog = useCallback(() => {

--- a/src/Trip/TripHome/TripHomeOnboarding.tsx
+++ b/src/Trip/TripHome/TripHomeOnboarding.tsx
@@ -30,10 +30,11 @@ export function TripHomeOnboarding() {
 
   const userCanModifyTrip = useMemo(() => {
     return (
-      trip?.currentUserRole === TripUserRole.Owner ||
-      trip?.currentUserRole === TripUserRole.Editor
+      trip?.archivedAt == null &&
+      (trip?.currentUserRole === TripUserRole.Owner ||
+        trip?.currentUserRole === TripUserRole.Editor)
     );
-  }, [trip?.currentUserRole]);
+  }, [trip]);
 
   const [, setLocation] = useLocation();
   const openActivityNewDialog = useCallback(() => {

--- a/src/Trip/TripHome/TripHomeTasks.tsx
+++ b/src/Trip/TripHome/TripHomeTasks.tsx
@@ -4,7 +4,7 @@ import { useMemo } from 'react';
 import { Link } from 'wouter';
 import { RouteTripTaskList } from '../../Routes/routes';
 import { TaskStatus } from '../../Task/TaskStatus';
-import { TripUserRole } from '../../User/TripUserRole';
+import { canModifyTripContent } from '../permissions';
 import {
   useCurrentTrip,
   useTripAllTaskLists,
@@ -14,13 +14,7 @@ import { TaskCard, TaskCardUseCase } from '../TripTask/TaskCard';
 
 export function TripHomeTasks() {
   const { trip } = useCurrentTrip();
-  const userCanModifyTrip = useMemo(() => {
-    return (
-      trip?.archivedAt == null &&
-      (trip?.currentUserRole === TripUserRole.Owner ||
-        trip?.currentUserRole === TripUserRole.Editor)
-    );
-  }, [trip]);
+  const userCanModifyTrip = canModifyTripContent(trip);
 
   // Get all task lists and tasks
   const allTaskLists = useTripAllTaskLists(trip?.id);

--- a/src/Trip/TripHome/TripHomeTasks.tsx
+++ b/src/Trip/TripHome/TripHomeTasks.tsx
@@ -16,10 +16,11 @@ export function TripHomeTasks() {
   const { trip } = useCurrentTrip();
   const userCanModifyTrip = useMemo(() => {
     return (
-      trip?.currentUserRole === TripUserRole.Owner ||
-      trip?.currentUserRole === TripUserRole.Editor
+      trip?.archivedAt == null &&
+      (trip?.currentUserRole === TripUserRole.Owner ||
+        trip?.currentUserRole === TripUserRole.Editor)
     );
-  }, [trip?.currentUserRole]);
+  }, [trip]);
 
   // Get all task lists and tasks
   const allTaskLists = useTripAllTaskLists(trip?.id);
@@ -120,7 +121,7 @@ export function TripHomeTasks() {
         ) : null}
       </Heading>
       <Flex gap="2" direction="column">
-        {displayTasks.length === 0 ? (
+        {displayTasks.length === 0 && userCanModifyTrip ? (
           <Button variant="outline" asChild style={{ alignSelf: 'start' }}>
             <Link to={RouteTripTaskList.asRouteTarget()}>Add first task</Link>
           </Button>

--- a/src/Trip/TripListView/TripListView.tsx
+++ b/src/Trip/TripListView/TripListView.tsx
@@ -26,7 +26,7 @@ import {
   RouteTripListViewActivity,
   RouteTripListViewMacroplan,
 } from '../../Routes/routes';
-import { TripUserRole } from '../../User/TripUserRole';
+import { canModifyTripContent } from '../permissions';
 import {
   useCurrentTrip,
   useTripAccommodations,
@@ -43,13 +43,7 @@ export function TripListView() {
     trip?.accommodationIds ?? [],
   );
   const tripMacroplans = useTripMacroplans(trip?.macroplanIds ?? []);
-  const userCanEditOrDelete = useMemo(() => {
-    return (
-      trip?.archivedAt == null &&
-      (trip?.currentUserRole === TripUserRole.Owner ||
-        trip?.currentUserRole === TripUserRole.Editor)
-    );
-  }, [trip]);
+  const userCanEditOrDelete = canModifyTripContent(trip);
 
   // Ref for the list container to enable scrolling
   const listContainerRef = useRef<HTMLDivElement>(null);

--- a/src/Trip/TripListView/TripListView.tsx
+++ b/src/Trip/TripListView/TripListView.tsx
@@ -45,10 +45,11 @@ export function TripListView() {
   const tripMacroplans = useTripMacroplans(trip?.macroplanIds ?? []);
   const userCanEditOrDelete = useMemo(() => {
     return (
-      trip?.currentUserRole === TripUserRole.Owner ||
-      trip?.currentUserRole === TripUserRole.Editor
+      trip?.archivedAt == null &&
+      (trip?.currentUserRole === TripUserRole.Owner ||
+        trip?.currentUserRole === TripUserRole.Editor)
     );
-  }, [trip?.currentUserRole]);
+  }, [trip]);
 
   // Ref for the list container to enable scrolling
   const listContainerRef = useRef<HTMLDivElement>(null);

--- a/src/Trip/TripMenu/TripMenu.tsx
+++ b/src/Trip/TripMenu/TripMenu.tsx
@@ -1,6 +1,6 @@
 import { HamburgerMenuIcon } from '@radix-ui/react-icons';
 import { Button, DropdownMenu, Flex } from '@radix-ui/themes';
-import { useCallback, useMemo } from 'react';
+import { useCallback } from 'react';
 import { Link, useLocation } from 'wouter';
 import { AccommodationNewDialog } from '../../Accommodation/AccommodationNewDialog';
 import { ActivityNewDialog } from '../../Activity/ActivityNewDialog';
@@ -13,8 +13,7 @@ import { postMutation } from '../../data/apiClient';
 import { useBoundStore } from '../../data/store';
 import { MacroplanNewDialog } from '../../Macroplan/MacroplanNewDialog';
 import { RouteAccount, RouteLogin, RouteTrips } from '../../Routes/routes';
-import { TripUserRole } from '../../User/TripUserRole';
-import { canModifyTripContent } from '../permissions';
+import { canModifyTripContent, isTripOwner } from '../permissions';
 import { useCurrentTrip } from '../store/hooks';
 import { TripArchiveDialog } from '../TripDialog/TripArchiveDialog';
 import { TripDeleteDialog } from '../TripDialog/TripDeleteDialog';
@@ -28,12 +27,8 @@ export function TripMenu() {
   const [, setLocation] = useLocation();
   const { trip } = useCurrentTrip();
   const user = useCurrentUser();
-  const userIsOwner = useMemo(() => {
-    return trip?.currentUserRole === TripUserRole.Owner;
-  }, [trip?.currentUserRole]);
-  const userCanModifyTrip = useMemo(() => {
-    return canModifyTripContent(trip);
-  }, [trip]);
+  const userIsOwner = isTripOwner(trip);
+  const userCanModifyTrip = canModifyTripContent(trip);
   const pushDialog = useBoundStore((state) => state.pushDialog);
 
   const handlePrintTrip = useCallback(

--- a/src/Trip/TripMenu/TripMenu.tsx
+++ b/src/Trip/TripMenu/TripMenu.tsx
@@ -14,7 +14,9 @@ import { useBoundStore } from '../../data/store';
 import { MacroplanNewDialog } from '../../Macroplan/MacroplanNewDialog';
 import { RouteAccount, RouteLogin, RouteTrips } from '../../Routes/routes';
 import { TripUserRole } from '../../User/TripUserRole';
+import { canModifyTripContent } from '../permissions';
 import { useCurrentTrip } from '../store/hooks';
+import { TripArchiveDialog } from '../TripDialog/TripArchiveDialog';
 import { TripDeleteDialog } from '../TripDialog/TripDeleteDialog';
 import { TripDuplicateDialog } from '../TripDialog/TripDuplicateDialog';
 import { TripEditDialog } from '../TripDialog/TripEditDialog';
@@ -30,11 +32,8 @@ export function TripMenu() {
     return trip?.currentUserRole === TripUserRole.Owner;
   }, [trip?.currentUserRole]);
   const userCanModifyTrip = useMemo(() => {
-    return (
-      trip?.currentUserRole === TripUserRole.Owner ||
-      trip?.currentUserRole === TripUserRole.Editor
-    );
-  }, [trip?.currentUserRole]);
+    return canModifyTripContent(trip);
+  }, [trip]);
   const pushDialog = useBoundStore((state) => state.pushDialog);
 
   const handlePrintTrip = useCallback(
@@ -148,9 +147,9 @@ export function TripMenu() {
           </DropdownMenu.Item>
 
           <DropdownMenu.Item
-            disabled={!user}
+            disabled={!user || trip?.archivedAt != null}
             onClick={
-              user
+              user && trip?.archivedAt == null
                 ? () => {
                     if (trip) {
                       pushDialog(TripDuplicateDialog, { trip });
@@ -216,9 +215,9 @@ export function TripMenu() {
           </DropdownMenu.Item>
 
           <DropdownMenu.Item
-            disabled={!userCanModifyTrip}
+            disabled={!userIsOwner}
             onClick={
-              userCanModifyTrip
+              userIsOwner
                 ? () => {
                     if (trip) {
                       pushDialog(TripDeleteDialog, { trip });
@@ -228,6 +227,21 @@ export function TripMenu() {
             }
           >
             Delete trip
+          </DropdownMenu.Item>
+
+          <DropdownMenu.Item
+            disabled={!userIsOwner}
+            onClick={
+              userIsOwner
+                ? () => {
+                    if (trip) {
+                      pushDialog(TripArchiveDialog, { trip });
+                    }
+                  }
+                : undefined
+            }
+          >
+            {trip?.archivedAt == null ? 'Archive trip' : 'Unarchive trip'}
           </DropdownMenu.Item>
 
           <DropdownMenu.Separator />

--- a/src/Trip/TripNavbar/TripNavbar.tsx
+++ b/src/Trip/TripNavbar/TripNavbar.tsx
@@ -71,6 +71,11 @@ export function TripNavbar() {
           <Link to={RouteTripHome.asRouteTarget()} className={s.tripTitle}>
             {trip?.title ?? <Skeleton>Trip title</Skeleton>}
           </Link>
+          {trip?.archivedAt != null ? (
+            <Badge color="gray" size="1">
+              Archived
+            </Badge>
+          ) : null}
           <DoubleArrowRightIcon className={s.tripTitleDivider} />
           {selector}
         </Heading>,

--- a/src/Trip/TripTask/TaskDialog/TaskDialogContentView.tsx
+++ b/src/Trip/TripTask/TaskDialog/TaskDialogContentView.tsx
@@ -34,10 +34,11 @@ export function TaskDialogContentView({
   const { trip } = useTrip(taskList?.tripId);
   const userCanEditOrDelete = useMemo(() => {
     return (
-      trip?.currentUserRole === TripUserRole.Owner ||
-      trip?.currentUserRole === TripUserRole.Editor
+      trip?.archivedAt == null &&
+      (trip?.currentUserRole === TripUserRole.Owner ||
+        trip?.currentUserRole === TripUserRole.Editor)
     );
-  }, [trip?.currentUserRole]);
+  }, [trip]);
 
   const descriptions = useParseTextIntoNodes(task?.description);
   const currentUser = useDeepBoundStore((state) => state.currentUser);

--- a/src/Trip/TripTask/TaskDialog/TaskDialogContentView.tsx
+++ b/src/Trip/TripTask/TaskDialog/TaskDialogContentView.tsx
@@ -8,7 +8,7 @@ import {
   Text,
 } from '@radix-ui/themes';
 
-import { useCallback, useMemo } from 'react';
+import { useCallback } from 'react';
 import { CommentGroupWithForm } from '../../../Comment/CommentGroupWithForm';
 import { COMMENT_GROUP_OBJECT_TYPE } from '../../../Comment/db';
 import { toFormat } from '../../../common/dateTime/temporalFormatter';
@@ -16,7 +16,7 @@ import { useParseTextIntoNodes } from '../../../common/text/parseTextIntoNodes';
 import type { DialogContentProps } from '../../../Dialog/DialogRoute';
 import { useDeepBoundStore } from '../../../data/store';
 import { getStatusColor, getStatusLabel } from '../../../Task/TaskStatus';
-import { TripUserRole } from '../../../User/TripUserRole';
+import { canModifyTripContent } from '../../permissions';
 import { useTrip, useTripTaskList } from '../../store/hooks';
 import type { TripSliceTask } from '../../store/types';
 import s from './TaskDialog.module.css';
@@ -32,13 +32,7 @@ export function TaskDialogContentView({
 }: DialogContentProps<TripSliceTask>) {
   const taskList = useTripTaskList(task?.taskListId ?? '');
   const { trip } = useTrip(taskList?.tripId);
-  const userCanEditOrDelete = useMemo(() => {
-    return (
-      trip?.archivedAt == null &&
-      (trip?.currentUserRole === TripUserRole.Owner ||
-        trip?.currentUserRole === TripUserRole.Editor)
-    );
-  }, [trip]);
+  const userCanEditOrDelete = canModifyTripContent(trip);
 
   const descriptions = useParseTextIntoNodes(task?.description);
   const currentUser = useDeepBoundStore((state) => state.currentUser);

--- a/src/Trip/TripTask/TaskList.tsx
+++ b/src/Trip/TripTask/TaskList.tsx
@@ -27,7 +27,7 @@ import { useShouldDisableDragAndDrop } from '../../common/deviceUtils';
 import { dangerToken } from '../../common/ui';
 import { useBoundStore } from '../../data/store';
 import { dbUpdateTaskList } from '../../Task/db';
-import { TripUserRole } from '../../User/TripUserRole';
+import { canModifyTripContent } from '../permissions';
 import { useCurrentTrip, useTripTaskList, useTripTasks } from '../store/hooks';
 import { TaskCard, TaskCardUseCase } from './TaskCard';
 import { TaskInlineForm } from './TaskInlineForm/TaskInlineForm';
@@ -53,13 +53,7 @@ export function TaskList({
   const publishToast = useBoundStore((state) => state.publishToast);
   const pushDialog = useBoundStore((state) => state.pushDialog);
 
-  const userCanEditOrDelete = useMemo(() => {
-    return (
-      trip?.archivedAt == null &&
-      (trip?.currentUserRole === TripUserRole.Owner ||
-        trip?.currentUserRole === TripUserRole.Editor)
-    );
-  }, [trip]);
+  const userCanEditOrDelete = canModifyTripContent(trip);
 
   // Focus the input when editing starts
   useEffect(() => {

--- a/src/Trip/TripTask/TaskList.tsx
+++ b/src/Trip/TripTask/TaskList.tsx
@@ -55,10 +55,11 @@ export function TaskList({
 
   const userCanEditOrDelete = useMemo(() => {
     return (
-      trip?.currentUserRole === TripUserRole.Owner ||
-      trip?.currentUserRole === TripUserRole.Editor
+      trip?.archivedAt == null &&
+      (trip?.currentUserRole === TripUserRole.Owner ||
+        trip?.currentUserRole === TripUserRole.Editor)
     );
-  }, [trip?.currentUserRole]);
+  }, [trip]);
 
   // Focus the input when editing starts
   useEffect(() => {

--- a/src/Trip/TripTask/TripTaskList.tsx
+++ b/src/Trip/TripTask/TripTaskList.tsx
@@ -27,7 +27,7 @@ import {
   dbUpdateTaskIndexes,
   dbUpdateTaskListIndexes,
 } from '../../Task/db';
-import { TripUserRole } from '../../User/TripUserRole';
+import { canModifyTripContent } from '../permissions';
 import { getSectionVisibility } from '../sectionVisibility';
 import {
   useCurrentTrip,
@@ -79,13 +79,7 @@ export function TripTaskList() {
     }),
   );
 
-  const userCanCreate = useMemo(() => {
-    return (
-      trip?.archivedAt == null &&
-      (trip?.currentUserRole === TripUserRole.Owner ||
-        trip?.currentUserRole === TripUserRole.Editor)
-    );
-  }, [trip]);
+  const userCanCreate = canModifyTripContent(trip);
 
   const handleCreateTaskList = useCallback(() => {
     setShowInlineForm(true);

--- a/src/Trip/TripTask/TripTaskList.tsx
+++ b/src/Trip/TripTask/TripTaskList.tsx
@@ -81,10 +81,11 @@ export function TripTaskList() {
 
   const userCanCreate = useMemo(() => {
     return (
-      trip?.currentUserRole === TripUserRole.Owner ||
-      trip?.currentUserRole === TripUserRole.Editor
+      trip?.archivedAt == null &&
+      (trip?.currentUserRole === TripUserRole.Owner ||
+        trip?.currentUserRole === TripUserRole.Editor)
     );
-  }, [trip?.currentUserRole]);
+  }, [trip]);
 
   const handleCreateTaskList = useCallback(() => {
     setShowInlineForm(true);

--- a/src/Trip/TripTimetableView/Timetable.tsx
+++ b/src/Trip/TripTimetableView/Timetable.tsx
@@ -291,10 +291,11 @@ export function Timetable() {
 
   const userCanModifyTrip = useMemo(() => {
     return (
-      trip?.currentUserRole === TripUserRole.Owner ||
-      trip?.currentUserRole === TripUserRole.Editor
+      trip?.archivedAt == null &&
+      (trip?.currentUserRole === TripUserRole.Owner ||
+        trip?.currentUserRole === TripUserRole.Editor)
     );
-  }, [trip?.currentUserRole]);
+  }, [trip]);
 
   // Days available for the day-swap context menu (derived once, not per header).
   const tripDays = useMemo(() => {

--- a/src/Trip/TripTimetableView/Timetable.tsx
+++ b/src/Trip/TripTimetableView/Timetable.tsx
@@ -51,8 +51,8 @@ import {
   RouteTripTimetableViewActivity,
   RouteTripTimetableViewMacroplan,
 } from '../../Routes/routes';
-import { TripUserRole } from '../../User/TripUserRole';
 import { IdeaSidebar } from '../Ideas/IdeaSidebar';
+import { canModifyTripContent } from '../permissions';
 import {
   useCurrentTrip,
   useTripAccommodations,
@@ -289,13 +289,7 @@ export function Timetable() {
     }
   }, [trip, hasScrolledForTrip]);
 
-  const userCanModifyTrip = useMemo(() => {
-    return (
-      trip?.archivedAt == null &&
-      (trip?.currentUserRole === TripUserRole.Owner ||
-        trip?.currentUserRole === TripUserRole.Editor)
-    );
-  }, [trip]);
+  const userCanModifyTrip = canModifyTripContent(trip);
 
   // Days available for the day-swap context menu (derived once, not per header).
   const tripDays = useMemo(() => {

--- a/src/Trip/TripTimetableView/TimetableGrid.tsx
+++ b/src/Trip/TripTimetableView/TimetableGrid.tsx
@@ -1,12 +1,12 @@
 import type { RefObject } from 'react';
-import React, { type MouseEvent, memo, useCallback, useMemo } from 'react';
+import React, { type MouseEvent, memo, useCallback } from 'react';
 import { AccommodationNewDialog } from '../../Accommodation/AccommodationNewDialog';
 import { ActivityNewDialog } from '../../Activity/ActivityNewDialog';
 import { FlightNewDialog } from '../../Activity/FlightNewDialog';
 import { TrainNewDialog } from '../../Activity/TrainNewDialog';
 import { useBoundStore } from '../../data/store';
 import { MacroplanNewDialog } from '../../Macroplan/MacroplanNewDialog';
-import { TripUserRole } from '../../User/TripUserRole';
+import { canModifyTripContent } from '../permissions';
 import { useCurrentTrip } from '../store/hooks';
 import { TimetableDragTarget } from './TimetableDragTarget';
 import { pad2 } from './time';
@@ -27,13 +27,7 @@ function TimetableGridInner({ days, scrollContainerRef }: TimetableGridProps) {
   const timeIntervals = [0, 30];
 
   const { trip } = useCurrentTrip();
-  const userCanModifyTrip = useMemo(() => {
-    return (
-      trip?.archivedAt == null &&
-      (trip?.currentUserRole === TripUserRole.Owner ||
-        trip?.currentUserRole === TripUserRole.Editor)
-    );
-  }, [trip]);
+  const userCanModifyTrip = canModifyTripContent(trip);
   const pushDialog = useBoundStore((state) => state.pushDialog);
 
   const openActivityNewDialog = useCallback(

--- a/src/Trip/TripTimetableView/TimetableGrid.tsx
+++ b/src/Trip/TripTimetableView/TimetableGrid.tsx
@@ -29,10 +29,11 @@ function TimetableGridInner({ days, scrollContainerRef }: TimetableGridProps) {
   const { trip } = useCurrentTrip();
   const userCanModifyTrip = useMemo(() => {
     return (
-      trip?.currentUserRole === TripUserRole.Owner ||
-      trip?.currentUserRole === TripUserRole.Editor
+      trip?.archivedAt == null &&
+      (trip?.currentUserRole === TripUserRole.Owner ||
+        trip?.currentUserRole === TripUserRole.Editor)
     );
-  }, [trip?.currentUserRole]);
+  }, [trip]);
   const pushDialog = useBoundStore((state) => state.pushDialog);
 
   const openActivityNewDialog = useCallback(

--- a/src/Trip/db.ts
+++ b/src/Trip/db.ts
@@ -60,6 +60,8 @@ export type DbTrip = {
   originRegion: string;
   /** origin's IANA time zone. Optional for backward compat */
   originTimeZone: string;
+  /** ms when archived; undefined while active */
+  archivedAt?: number;
 
   /** 0: private; 1: group (removed, no longer in use); 2: public but unlisted; 3: public listed in public directory */
   sharingLevel: TripSharingLevelType;
@@ -189,6 +191,12 @@ export async function dbUpdateTripSharingLevel(
         sharingLevel,
       }),
   );
+}
+
+export async function dbSetTripArchived(tripId: string, archived: boolean) {
+  return patchMutation(`/api/trips/${encodeURIComponent(tripId)}/archive`, {
+    archived,
+  });
 }
 
 export async function dbDeleteTrip(trip: TripSliceTrip) {

--- a/src/Trip/permissions.ts
+++ b/src/Trip/permissions.ts
@@ -8,3 +8,7 @@ export function canModifyTripContent(trip: TripSliceTrip | undefined): boolean {
       trip?.currentUserRole === TripUserRole.Editor)
   );
 }
+
+export function isTripOwner(trip: TripSliceTrip | undefined): boolean {
+  return trip?.currentUserRole === TripUserRole.Owner;
+}

--- a/src/Trip/permissions.ts
+++ b/src/Trip/permissions.ts
@@ -1,0 +1,10 @@
+import { TripUserRole } from '../User/TripUserRole';
+import type { TripSliceTrip } from './store/types';
+
+export function canModifyTripContent(trip: TripSliceTrip | undefined): boolean {
+  return (
+    trip?.archivedAt == null &&
+    (trip?.currentUserRole === TripUserRole.Owner ||
+      trip?.currentUserRole === TripUserRole.Editor)
+  );
+}

--- a/src/Trip/store/deriveState.ts
+++ b/src/Trip/store/deriveState.ts
@@ -43,6 +43,7 @@ export function deriveNewTripState(
       originCurrency: trip.originCurrency,
       originRegion: trip.originRegion ?? '',
       originTimeZone: trip.originTimeZone ?? '',
+      archivedAt: trip.archivedAt,
       timeZone: trip.timeZone,
       accommodationIds: trip.accommodation.map((a) => a.id),
       activityIds: trip.activity.map((a) => a.id),

--- a/src/Trip/store/types.ts
+++ b/src/Trip/store/types.ts
@@ -146,6 +146,7 @@ export type DbTripQueryReturnType = {
   originCurrency: string;
   originRegion?: string | null;
   originTimeZone?: string | null;
+  archivedAt?: number;
   timeZone: string;
   sharingLevel: number;
   publicShowExpenses?: boolean | null;

--- a/src/Trips/PageTrips.tsx
+++ b/src/Trips/PageTrips.tsx
@@ -21,6 +21,7 @@ import {
   RouteAccountUpgrade,
   RouteTripNew,
   RouteTrips,
+  RouteTripsArchived,
   RouteTripsPublic,
 } from '../Routes/routes';
 import { TripGroup, type TripGroupType } from '../Trip/TripGroup';
@@ -119,6 +120,9 @@ export function PageTrips(_props: RouteComponentProps) {
             Load more
           </Button>
         ) : null}
+        <Button mx="2" my="4" size="2" color="gray" variant="outline" asChild>
+          <Link to={RouteTripsArchived.asRootRoute()}>Archived Trips</Link>
+        </Button>
         <Button mx="2" my="4" size="2" color="gray" variant="outline" asChild>
           <Link to={RouteTripsPublic.asRootRoute()}>Explore Public Trips</Link>
         </Button>

--- a/src/Trips/PageTripsArchived.tsx
+++ b/src/Trips/PageTripsArchived.tsx
@@ -1,0 +1,108 @@
+import {
+  Button,
+  Callout,
+  Container,
+  Flex,
+  Heading,
+  Skeleton,
+} from '@radix-ui/themes';
+import { useEffect } from 'react';
+import { Link, type RouteComponentProps } from 'wouter';
+import { useCurrentUser } from '../Auth/hooks';
+import { UserAvatarMenu } from '../Auth/UserAvatarMenu';
+import { useBoundStore, useDeepBoundStore } from '../data/store';
+import { DocTitle } from '../Nav/DocTitle';
+import { Navbar } from '../Nav/Navbar';
+import { RouteTrips } from '../Routes/routes';
+import s from './PageTrips.module.css';
+import { TripCard } from './TripCard';
+
+export default PageTripsArchived;
+
+export function PageTripsArchived(_props: RouteComponentProps) {
+  const currentUser = useCurrentUser();
+  const subscribeArchivedTrips = useBoundStore(
+    (state) => state.subscribeArchivedTrips,
+  );
+  useEffect(() => {
+    if (!currentUser) return;
+    return subscribeArchivedTrips(currentUser.id);
+  }, [currentUser, subscribeArchivedTrips]);
+  const trips = useDeepBoundStore((state) =>
+    currentUser
+      ? (state.archivedTrips[JSON.stringify({ tripUser: currentUser.id })] ??
+        [])
+      : [],
+  );
+  const loading = useDeepBoundStore((state) => state.archivedTripsLoading);
+  const error = useDeepBoundStore((state) => state.archivedTripsError);
+  const hasMore = useDeepBoundStore((state) => state.archivedTripsHasMore);
+  const loadMore = useDeepBoundStore((state) => state.archivedTripsLoadMore);
+  const loadingMore = useDeepBoundStore(
+    (state) => state.archivedTripsLoadingMore,
+  );
+
+  return (
+    <>
+      <DocTitle title="Archived Trips" />
+      <Navbar
+        leftItems={[
+          <Heading as="h2" size="5" key="archivedTrips">
+            Archived Trips
+          </Heading>,
+        ]}
+        rightItems={[
+          <UserAvatarMenu user={currentUser} key="userAvatarMenu" />,
+        ]}
+      />
+      <Container>
+        <Button mx="2" my="4" size="2" color="gray" variant="outline" asChild>
+          <Link to={RouteTrips.asRootRoute()}>Back to Trips</Link>
+        </Button>
+        {error ? (
+          <Callout.Root my="2">
+            <Callout.Text>Error loading archived trips: {error}</Callout.Text>
+          </Callout.Root>
+        ) : null}
+        <Flex asChild gap="2" p="2" wrap="wrap">
+          <ul>
+            {loading ? (
+              <Skeleton>
+                <TripCard
+                  className={s.tripLi}
+                  trip={{
+                    id: 'skeleton',
+                    title: 'Loading...',
+                    timestampStart: 0,
+                    timestampEnd: 0,
+                    timeZone: 'UTC',
+                    createdAt: 0,
+                    lastUpdatedAt: 0,
+                  }}
+                />
+              </Skeleton>
+            ) : trips.length === 0 ? (
+              'No archived trips.'
+            ) : (
+              trips.map((trip) => (
+                <TripCard className={s.tripLi} trip={trip} key={trip.id} />
+              ))
+            )}
+          </ul>
+        </Flex>
+        {hasMore ? (
+          <Button
+            variant="outline"
+            color="gray"
+            onClick={loadMore}
+            mx="2"
+            my="4"
+            loading={!!loadingMore}
+          >
+            Load more
+          </Button>
+        ) : null}
+      </Container>
+    </>
+  );
+}

--- a/src/Trips/TripCard.tsx
+++ b/src/Trips/TripCard.tsx
@@ -1,4 +1,4 @@
-import { Card, Text } from '@radix-ui/themes';
+import { Badge, Card, Text } from '@radix-ui/themes';
 import clsx from 'clsx';
 import { Link } from 'wouter';
 import { RouteTrip, RouteTripHome } from '../Routes/routes';
@@ -52,6 +52,9 @@ export function TripCard({
             tripStartDateTime={tripStartDateTime}
             tripEndDateTime={tripEndDateTime}
           />
+          {trip.archivedAt != null ? (
+            <Badge color="gray">Archived</Badge>
+          ) : null}
         </Link>
       </Card>
     </li>

--- a/src/Trips/store.ts
+++ b/src/Trips/store.ts
@@ -11,6 +11,7 @@ export type TripsSliceTrip = {
   timeZone: string;
   createdAt: number;
   lastUpdatedAt: number;
+  archivedAt?: number | null;
 };
 export type TripsSlice = {
   trips: { [queryKey: string]: TripsSliceTrip[] };
@@ -24,6 +25,13 @@ export type TripsSlice = {
   tripsHasMore: null | boolean;
   tripsLoadMore: undefined | (() => void);
   tripsLoadingMore: null | boolean;
+  archivedTrips: { [queryKey: string]: TripsSliceTrip[] };
+  archivedTripsLoading: boolean;
+  archivedTripsError: string | null;
+  archivedTripsHasMore: null | boolean;
+  archivedTripsLoadMore: undefined | (() => void);
+  archivedTripsLoadingMore: null | boolean;
+  subscribeArchivedTrips: (currentUserId: string) => () => void;
 };
 
 type ApiTrip = {
@@ -34,7 +42,21 @@ type ApiTrip = {
   timeZone: string;
   createdAt: number;
   lastUpdatedAt: number;
+  archivedAt?: number;
 };
+
+function toTripsSliceTrip(trip: ApiTrip): TripsSliceTrip {
+  return {
+    ...trip,
+    // MySQL BIGINT ms fields can be JSON strings; coerce so TripCard's
+    // Temporal.Instant.fromEpochMilliseconds does not fail.
+    timestampStart: Number(trip.timestampStart),
+    timestampEnd: Number(trip.timestampEnd),
+    createdAt: Number(trip.createdAt),
+    lastUpdatedAt: Number(trip.lastUpdatedAt),
+    archivedAt: trip.archivedAt == null ? undefined : Number(trip.archivedAt),
+  };
+}
 
 export const createTripsSlice: StateCreator<
   BoundStoreType,
@@ -48,6 +70,12 @@ export const createTripsSlice: StateCreator<
   tripsHasMore: null,
   tripsLoadMore: undefined,
   tripsLoadingMore: null,
+  archivedTrips: {},
+  archivedTripsLoading: false,
+  archivedTripsError: null,
+  archivedTripsHasMore: null,
+  archivedTripsLoadMore: undefined,
+  archivedTripsLoadingMore: null,
   subscribeTrips: (currentUserId, now) => {
     const queryKey = getQueryKey(currentUserId);
     let disposed = false;
@@ -57,15 +85,6 @@ export const createTripsSlice: StateCreator<
     let activeLoaded = false;
     let pastLoaded = false;
 
-    const toTrip = (trip: ApiTrip): TripsSliceTrip => ({
-      ...trip,
-      // MySQL BIGINT ms fields can be JSON strings; coerce so TripCard's
-      // Temporal.Instant.fromEpochMilliseconds does not fail.
-      timestampStart: Number(trip.timestampStart),
-      timestampEnd: Number(trip.timestampEnd),
-      createdAt: Number(trip.createdAt),
-      lastUpdatedAt: Number(trip.lastUpdatedAt),
-    });
     const merge = () => {
       if (disposed || !activeLoaded || !pastLoaded) return;
       set((state) => ({
@@ -84,12 +103,12 @@ export const createTripsSlice: StateCreator<
         const page = await get<CursorPage<ApiTrip>>(`/api/trips?${params}`);
         if (disposed) return;
         if (append) {
-          pastTrips = [...pastTrips, ...page.data.map(toTrip)];
+          pastTrips = [...pastTrips, ...page.data.map(toTripsSliceTrip)];
           pastCursor = page.nextCursor;
           pastLoaded = true;
           set(() => ({ tripsHasMore: page.hasMore, tripsLoadingMore: false }));
         } else {
-          activeTrips = page.data.map(toTrip);
+          activeTrips = page.data.map(toTripsSliceTrip);
           activeLoaded = true;
         }
         merge();
@@ -124,6 +143,62 @@ export const createTripsSlice: StateCreator<
     return () => {
       disposed = true;
       set(() => ({ tripsLoadMore: undefined }));
+    };
+  },
+  subscribeArchivedTrips: (currentUserId) => {
+    const queryKey = getQueryKey(currentUserId);
+    let disposed = false;
+    let cursor: string | null = null;
+    let archivedTrips: TripsSliceTrip[] = [];
+    const load = async (append = false): Promise<void> => {
+      try {
+        const params = new URLSearchParams({
+          status: 'archived',
+          limit: append ? '10' : '100',
+        });
+        if (append && cursor) params.set('cursor', cursor);
+        const page = await get<CursorPage<ApiTrip>>(`/api/trips?${params}`);
+        if (disposed) return;
+        archivedTrips = append
+          ? [...archivedTrips, ...page.data.map(toTripsSliceTrip)]
+          : page.data.map(toTripsSliceTrip);
+        cursor = page.nextCursor;
+        set((state) => ({
+          archivedTrips: { ...state.archivedTrips, [queryKey]: archivedTrips },
+          archivedTripsLoading: false,
+          archivedTripsLoadingMore: false,
+          archivedTripsHasMore: page.hasMore,
+        }));
+      } catch (error: unknown) {
+        if (disposed) return;
+        set(() => ({
+          archivedTripsLoading: false,
+          archivedTripsLoadingMore: false,
+          archivedTripsError:
+            error instanceof Error
+              ? error.message
+              : 'Unable to load archived trips',
+        }));
+      }
+    };
+    set(() => ({
+      archivedTripsLoading: true,
+      archivedTripsError: null,
+      archivedTripsLoadingMore: false,
+    }));
+    void load();
+    set(() => ({
+      archivedTripsLoadMore: () => {
+        const state = getState();
+        if (state.archivedTripsLoadingMore || !state.archivedTripsHasMore)
+          return;
+        set(() => ({ archivedTripsLoadingMore: true }));
+        void load(true);
+      },
+    }));
+    return () => {
+      disposed = true;
+      set(() => ({ archivedTripsLoadMore: undefined }));
     };
   },
   getTripsGrouped: (currentUserId, now) => {

--- a/src/data/apiTrip.ts
+++ b/src/data/apiTrip.ts
@@ -25,6 +25,7 @@ export function mapApiTrip(trip: ApiTrip): DbTripQueryReturnType {
     timeZone: row.timeZone ?? row.timezone,
     createdAt: toNum(row.createdAt ?? row.created_at_ms),
     lastUpdatedAt: toNum(row.lastUpdatedAt ?? row.updated_at_ms),
+    archivedAt: toNum(row.archivedAt ?? row.archived_at_ms),
     timestampCheckIn: toNum(row.timestampCheckIn ?? row.check_in_ms),
     timestampCheckOut: toNum(row.timestampCheckOut ?? row.check_out_ms),
     timeZoneCheckIn: row.timeZoneCheckIn ?? row.tz_check_in,

--- a/src/webmcp/WebMCPTools.tsx
+++ b/src/webmcp/WebMCPTools.tsx
@@ -1,5 +1,5 @@
 import { useBoundStore } from '../data/store';
-import { TripUserRole } from '../User/TripUserRole';
+import { canModifyTripContent, isTripOwner } from '../Trip/permissions';
 import { createAccommodationTools } from './accommodation.tools';
 import { createActivityTools } from './activity.tools';
 import { createAuthTools } from './auth.tools';
@@ -35,12 +35,9 @@ export function WebMCPTools() {
   const tripLoaded = Boolean(currentTrip);
   const canEdit =
     currentTrip?.isCurrentUserTripMember === true &&
-    currentTrip.archivedAt == null &&
-    (currentTrip.currentUserRole === TripUserRole.Owner ||
-      currentTrip.currentUserRole === TripUserRole.Editor);
+    canModifyTripContent(currentTrip);
   const canManage =
-    currentTrip?.isCurrentUserTripMember === true &&
-    currentTrip.currentUserRole === TripUserRole.Owner;
+    currentTrip?.isCurrentUserTripMember === true && isTripOwner(currentTrip);
 
   // Do not advertise login/signup to an already authenticated assistant, or
   // account/logout tools to a logged-out one.

--- a/src/webmcp/WebMCPTools.tsx
+++ b/src/webmcp/WebMCPTools.tsx
@@ -35,6 +35,7 @@ export function WebMCPTools() {
   const tripLoaded = Boolean(currentTrip);
   const canEdit =
     currentTrip?.isCurrentUserTripMember === true &&
+    currentTrip.archivedAt == null &&
     (currentTrip.currentUserRole === TripUserRole.Owner ||
       currentTrip.currentUserRole === TripUserRole.Editor);
   const canManage =

--- a/src/webmcp/WebMCPTools.tsx
+++ b/src/webmcp/WebMCPTools.tsx
@@ -54,9 +54,13 @@ export function WebMCPTools() {
   const tripReadWriteTools: WebMCPTool[] = authenticated
     ? [
         ...createTripTools().filter((tool) =>
-          ['trip-list', 'trip-open', 'trip-get', 'trip-create'].includes(
-            tool.name,
-          ),
+          [
+            'trip-list',
+            'trip-list-archived',
+            'trip-open',
+            'trip-get',
+            'trip-create',
+          ].includes(tool.name),
         ),
         ...createPlaceTools(),
       ]
@@ -91,6 +95,7 @@ export function WebMCPTools() {
                 [
                   'trip-update-sharing',
                   'trip-update-sections',
+                  'trip-set-archived',
                   'trip-add-member',
                   'trip-update-member',
                 ].includes(tool.name),

--- a/src/webmcp/tools.contract.test.ts
+++ b/src/webmcp/tools.contract.test.ts
@@ -28,6 +28,18 @@ describe('WebMCP reliability contracts', () => {
     });
   });
 
+  it('exposes archived-trip listing and owner archive state controls', () => {
+    const tools = createTripTools();
+    expect(named('trip-list-archived', tools)).toMatchObject({
+      annotations: { readOnlyHint: true },
+    });
+    const archive = named('trip-set-archived', tools);
+    expect(archive.inputSchema.required).toContain('archived');
+    expect(archive.inputSchema.properties.archived).toMatchObject({
+      type: 'boolean',
+    });
+  });
+
   it('exposes bounded activity batches and itinerary relationship fields', () => {
     const tool = named('activity-create-many', createActivityTools());
     const activities = tool.inputSchema.properties.activities as {

--- a/src/webmcp/trip.tools.ts
+++ b/src/webmcp/trip.tools.ts
@@ -4,6 +4,7 @@ import { useBoundStore } from '../data/store';
 import {
   dbAddTrip,
   dbAddUserToTrip,
+  dbSetTripArchived,
   dbUpdateTrip,
   dbUpdateTripSectionVisibility,
   dbUpdateTripSharingLevel,
@@ -16,7 +17,7 @@ import {
 import { TripUserRole } from '../User/TripUserRole';
 import { idempotencyKeySchema, runIdempotent } from './idempotency';
 import type { WebMCPTool } from './modelContext';
-import { asOptStr, asStr, int, str, strEnum } from './schema';
+import { asOptStr, asStr, bool, int, str, strEnum } from './schema';
 import { epochToTripDate, resolveTripDates } from './tripDates';
 
 type TripSummary = {
@@ -25,6 +26,7 @@ type TripSummary = {
   timestampStart: number;
   timestampEnd: number;
   timeZone: string;
+  archivedAt?: number;
 };
 
 function requireAuthUser(): { id: string } {
@@ -65,6 +67,7 @@ function tripSnapshot(id: string): Record<string, unknown> {
     taskListIds: t.taskListIds,
     tripUserIds: t.tripUserIds,
     commentGroupIds: t.commentGroupIds,
+    archivedAt: t.archivedAt,
   };
 }
 
@@ -83,6 +86,13 @@ async function listTripsFromApi(): Promise<TripSummary[]> {
   return [...active, ...past];
 }
 
+async function listArchivedTripsFromApi(): Promise<TripSummary[]> {
+  const page = await apiGet<CursorPage<TripSummary>>(
+    '/api/trips?status=archived&limit=100',
+  );
+  return page.data;
+}
+
 export function createTripTools(): WebMCPTool[] {
   // Owners cannot be assigned through the UI or backend member endpoints.
   const memberRoleValues = [TripUserRole.Viewer, TripUserRole.Editor];
@@ -90,12 +100,24 @@ export function createTripTools(): WebMCPTool[] {
     {
       name: 'trip-list',
       description:
-        'Lists the current user’s trips (id, title, dates, timezone). Fetches the latest from the backend.',
+        'Lists the current user’s non-archived trips (id, title, dates, timezone). Fetches the latest from the backend.',
       inputSchema: { type: 'object', properties: {} },
       annotations: { readOnlyHint: true },
       async execute() {
         requireAuthUser();
         const trips = await listTripsFromApi();
+        return { ok: true, trips };
+      },
+    },
+    {
+      name: 'trip-list-archived',
+      description:
+        'Lists the current user’s archived trips (id, title, dates, timezone, archivedAt), newest archived first. Fetches the latest from the backend.',
+      inputSchema: { type: 'object', properties: {} },
+      annotations: { readOnlyHint: true },
+      async execute() {
+        requireAuthUser();
+        const trips = await listArchivedTripsFromApi();
         return { ok: true, trips };
       },
     },
@@ -297,6 +319,30 @@ export function createTripTools(): WebMCPTool[] {
         }
         await dbUpdateTripSharingLevel(tripId, level);
         return { ok: true, tripId, sharingLevel: level };
+      },
+    },
+    {
+      name: 'trip-set-archived',
+      description:
+        'Archives or unarchives a trip. Only owners may change this state. Archiving makes trip content read-only; sharing, members, and deletion remain available.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          tripId: str('Trip id. Defaults to the currently open trip.'),
+          archived: bool('True to archive, false to unarchive.'),
+        },
+        required: ['archived'],
+      },
+      async execute(input) {
+        assertWritable('changing trip archive state');
+        requireAuthUser();
+        const tripId =
+          (input.tripId as string | undefined) ?? requireCurrentTrip();
+        if (typeof input.archived !== 'boolean') {
+          throw new Error('archived is required and must be a boolean');
+        }
+        await dbSetTripArchived(tripId, input.archived);
+        return { ok: true, tripId, archived: input.archived };
       },
     },
     {


### PR DESCRIPTION
## Why

Owners need a way to retire a finished trip without losing its data. Today, trips are grouped by end date into upcoming/ongoing/past, and there is no way to signal "this trip is done — stop editing it" without deleting it. Past trips remain fully editable, so a completed trip can still be mutated by accident.

## What

- New nullable `trips.archived_at_ms` column (migration + index) exposed as `archivedAt` in trip-list, full-trip, and public payloads.
- New owner-only, idempotent endpoint `PATCH /api/trips/{trip}/archive` (`{ archived: true|false }`) — unshar-share of the trip is now explicit; existing visibility/sharing is preserved.
- `GET /api/trips?status=archived` returns a paginated, `archived_at_ms`-descending list; archived trips are excluded from active/past (and default) list queries.
- Server-enforced content write lock: all content mutations — trip metadata, activities, accommodations, macroplans, expenses, tasks, comments, batch/drag/duplicate, and direct-ID routes — reject with `409 Conflict` when archived. Owner sharing changes, member management, and deletion remain allowed.
- Frontend: Archived Trips page with its own subscription/pagination, archive/unarchive confirmation dialog in the owner trip menu, "Archived" badge on trip cards and navbar, persistent read-only banner on the trip page, and all content-edit controls gated behind a shared `canModifyTripContent` permission.

## How

- Centralized the archive write-lock in `TripAccessService::ensureContentWritable()`, applied both as a `trip.writable` route middleware on trip-scoped routes and inline in controllers that resolve content by ID (activities, tasks, comments).
- Trip list query branches on `status`: `archived` filters `archived_at_ms IS NOT NULL` and orders by it; everything else filters it to NULL and keeps the existing active/past grouping and ordering.
- Archive/unarchive sets or clears `archived_at_ms` (idempotent — repeat requests keep the original timestamp) and is gated to owners via the existing `trip.access:manage` middleware.
- Frontend permission checks route through a single `canModifyTripContent` helper so edit affordances disappear consistently across dialogs, home, timetables, tasks, expenses, comments, and WebMCP tools.

## Tests

- `TripArchivalTest`: archive/unarchive idempotency, owner-only state changes, list filtering/ordering, conflict on all content mutations, and preserved reads/sharing/members/deletion.
- `ApiMigrationTest`: archive flow plus the archived-trip authorization matrix and sync serialization coverage.