### PR TITLE
fix(map): correct route arrow rotation

### DIFF
--- a/src/Map/geometry.test.ts
+++ b/src/Map/geometry.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'vitest';
 import { type Line, RouteType } from './constants';
-import { createGeoJsonData } from './geometry';
+import { calculateArrowRotation, createGeoJsonData } from './geometry';
 
 const from = { lat: 1.3521, lng: 103.8198 };
 const to = { lat: 35.6762, lng: 139.6503 };
@@ -10,6 +10,13 @@ function makeLine(id: string, type: Line['type'] = RouteType.Activity): Line {
 }
 
 describe('createGeoJsonData', () => {
+  test('rotates arrows clockwise from the east-facing glyph', () => {
+    expect(calculateArrowRotation([0, 0], [1, 0])).toBe(0);
+    expect(calculateArrowRotation([0, 0], [0, 1])).toBe(-90);
+    expect(calculateArrowRotation([0, 0], [0, -1])).toBe(90);
+    expect(Math.abs(calculateArrowRotation([0, 0], [-1, 0]))).toBe(180);
+  });
+
   test('preserves route types and adds destination-side arrows', () => {
     const data = createGeoJsonData([
       makeLine('activity', RouteType.Activity),

--- a/src/Map/geometry.ts
+++ b/src/Map/geometry.ts
@@ -89,14 +89,16 @@ function curveLane(index: number): number {
   return index % 2 === 1 ? -magnitude : magnitude;
 }
 
-function calculateArrowRotation(
+export function calculateArrowRotation(
   previous: number[] | undefined,
   point: number[] | undefined,
 ): number {
   if (!previous || !point) return 0;
   const deltaLng = point[0] - previous[0];
   const deltaLat = point[1] - previous[1];
-  return (Math.atan2(deltaLat, deltaLng) * 180) / Math.PI;
+  // MapLibre rotates text clockwise, while latitude increases northward.
+  const rotation = (-Math.atan2(deltaLat, deltaLng) * 180) / Math.PI;
+  return rotation === 0 ? 0 : rotation;
 }
 
 /**


### PR DESCRIPTION
## Summary

- correct route arrow rotation for MapLibre
- add cardinal-direction coverage for arrow rotation

## Testing

- `npx vitest run src/Map/geometry.test.ts --reporter=dot`
- `npm run typecheck`
- `npx biome ci src/Map/geometry.ts src/Map/geometry.test.ts`