### PR TITLE
fix(list): keep sticky day headers above activities

### DIFF
--- a/src/Trip/TripListView/TripListView.module.css
+++ b/src/Trip/TripListView/TripListView.module.css
@@ -12,6 +12,8 @@
   flex: 0 0 auto;
   position: sticky;
   top: 0;
+  /* Keep sticky day headers above hovered/focused activity cards (z-index: 3). */
+  z-index: 4;
   background: var(--color-panel-solid);
   border-bottom: 1px solid var(--gray-7);
   padding-top: var(--space-1);


### PR DESCRIPTION
## Summary

- keep sticky list day headers above hovered and focused activity cards
- scope the stacking fix to the list stylesheet so timetable layering is unchanged

## Testing

- `npx biome ci src/Trip/TripListView/TripListView.module.css`